### PR TITLE
Add test workflows for Github node

### DIFF
--- a/workflows/39.json
+++ b/workflows/39.json
@@ -1,699 +1,697 @@
-[
-  {
-    "id": 39,
-    "name": "Github:Repository:get getProfile getLicense listPopularPaths listReferrers:File:create edit get delete:Issue:create createComment edit get lock:Release: create:User:getRepositories invite:Review:create getAll get update",
-    "active": false,
-    "nodes": [
-      {
-        "parameters": {},
-        "name": "Start",
-        "type": "n8n-nodes-base.start",
-        "typeVersion": 1,
-        "position": [
-          180,
-          750
-        ]
+{
+  "id": 39,
+  "name": "Github:Repository:get getProfile getLicense listPopularPaths listReferrers:File:create edit get delete:Issue:create createComment edit get lock:Release: create:User:getRepositories invite:Review:create getAll get update",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        180,
+        750
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "repository",
+        "operation": "getProfile",
+        "owner": "nodemationqa",
+        "repository": "nodeQA"
       },
-      {
-        "parameters": {
-          "resource": "repository",
-          "operation": "getProfile",
-          "owner": "nodemationqa",
-          "repository": "nodeQA"
-        },
-        "name": "GitHub",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          620,
-          300
-        ],
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "repository",
-          "operation": "getLicense",
-          "owner": "nodemationqa",
-          "repository": "nodeQA"
-        },
-        "name": "GitHub1",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          770,
-          300
-        ],
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "repository",
-          "operation": "listPopularPaths",
-          "owner": "nodemationqa",
-          "repository": "nodeQA"
-        },
-        "name": "GitHub2",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          920,
-          300
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "repository",
-          "operation": "listReferrers",
-          "owner": "nodemationqa",
-          "repository": "nodeQA"
-        },
-        "name": "GitHub3",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          1070,
-          300
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "repository",
-          "operation": "get",
-          "owner": "nodemationqa",
-          "repository": "nodeQA"
-        },
-        "name": "GitHub4",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          470,
-          300
-        ],
-        "executeOnce": false,
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "repository",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "getRepositoryIssuesFilters": {}
-        },
-        "name": "GitHub5",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          1210,
-          300
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        },
-        "disabled": true
-      },
-      {
-        "parameters": {
-          "resource": "file",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "filePath": "testFile",
-          "fileContent": "Test file content, create file operation",
-          "commitMessage": "=Commited {{(new Date()).toGMTString()}}",
-          "additionalParameters": {
-            "branch": {
-              "branch": "main"
-            }
-          }
-        },
-        "name": "GitHub6",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          470,
-          460
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "file",
-          "operation": "edit",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "filePath": "testFile",
-          "fileContent": "Updated Test file content, create file operation",
-          "commitMessage": "=Updated commit message {{(new Date()).toGMTString()}}",
-          "additionalParameters": {
-            "branch": {
-              "branch": "main"
-            }
-          }
-        },
-        "name": "GitHub7",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          630,
-          460
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "file",
-          "operation": "get",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "filePath": "testFile",
-          "asBinaryProperty": false
-        },
-        "name": "GitHub8",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          770,
-          460
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "file",
-          "operation": "delete",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "filePath": "testFile",
-          "commitMessage": "=delete commit message {{(new Date()).toGMTString()}}",
-          "additionalParameters": {
-            "branch": {
-              "branch": "main"
-            }
-          }
-        },
-        "name": "GitHub9",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          910,
-          460
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "title": "=Test Issue created at {{(new Date()).toGMTString()}}",
-          "body": "=Test issue body  {{(new Date()).toGMTString()}}",
-          "labels": [],
-          "assignees": []
-        },
-        "name": "GitHub10",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          470,
-          620
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "operation": "createComment",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
-          "body": "=Comment on issue at {{(new Date()).toGMTString()}}"
-        },
-        "name": "GitHub11",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          620,
-          620
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "operation": "edit",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
-          "editFields": {
-            "title": "=Updated {{$node[\"GitHub10\"].json[\"title\"]}}",
-            "body": "=updated Test issue body {{(new Date()).toGMTString()}}"
-          }
-        },
-        "name": "GitHub12",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          770,
-          620
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "operation": "get",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}"
-        },
-        "name": "GitHub13",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          920,
-          620
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "operation": "lock",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
-          "lockReason": "spam"
-        },
-        "name": "GitHub14",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          1060,
-          620
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "release",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "releaseTag": "release_test_tag",
-          "additionalFields": {
-            "name": "=Release tag {{(new Date()).toGMTString()}}",
-            "draft": true
-          }
-        },
-        "name": "GitHub15",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          470,
-          770
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "user",
-          "owner": "nodemationqa"
-        },
-        "name": "GitHub16",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          470,
-          930
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "user",
-          "operation": "invite",
-          "organization": "OrgnodeQA",
-          "email": "nodeqa@n8n.io"
-        },
-        "name": "GitHub17",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          660,
-          930
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "review",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "pullRequestNumber": 3,
-          "event": "comment",
-          "body": "=Review Test {{(new Date()).toGMTString()}}",
-          "additionalFields": {}
-        },
-        "name": "GitHub18",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          460,
-          1080
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "review",
-          "operation": "getAll",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "pullRequestNumber": 3,
-          "limit": 1
-        },
-        "name": "GitHub19",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          610,
-          1080
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "review",
-          "operation": "get",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "pullRequestNumber": 3,
-          "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}"
-        },
-        "name": "GitHub20",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          750,
-          1080
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      },
-      {
-        "parameters": {
-          "resource": "review",
-          "operation": "update",
-          "owner": "nodemationqa",
-          "repository": "nodeQA",
-          "pullRequestNumber": 3,
-          "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}",
-          "body": "=Updated {{$node[\"GitHub18\"].json[\"body\"]}}"
-        },
-        "name": "GitHub21",
-        "type": "n8n-nodes-base.github",
-        "typeVersion": 1,
-        "position": [
-          900,
-          1080
-        ],
-        "alwaysOutputData": true,
-        "credentials": {
-          "githubApi": "Github creds"
-        }
-      }
-    ],
-    "connections": {
-      "Start": {
-        "main": [
-          [
-            {
-              "node": "GitHub4",
-              "type": "main",
-              "index": 0
-            },
-            {
-              "node": "GitHub6",
-              "type": "main",
-              "index": 0
-            },
-            {
-              "node": "GitHub10",
-              "type": "main",
-              "index": 0
-            },
-            {
-              "node": "GitHub15",
-              "type": "main",
-              "index": 0
-            },
-            {
-              "node": "GitHub16",
-              "type": "main",
-              "index": 0
-            },
-            {
-              "node": "GitHub18",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub": {
-        "main": [
-          [
-            {
-              "node": "GitHub1",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub1": {
-        "main": [
-          [
-            {
-              "node": "GitHub2",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub2": {
-        "main": [
-          [
-            {
-              "node": "GitHub3",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub3": {
-        "main": [
-          [
-            {
-              "node": "GitHub5",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub4": {
-        "main": [
-          [
-            {
-              "node": "GitHub",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub8": {
-        "main": [
-          [
-            {
-              "node": "GitHub9",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub6": {
-        "main": [
-          [
-            {
-              "node": "GitHub7",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub7": {
-        "main": [
-          [
-            {
-              "node": "GitHub8",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub10": {
-        "main": [
-          [
-            {
-              "node": "GitHub11",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub11": {
-        "main": [
-          [
-            {
-              "node": "GitHub12",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub12": {
-        "main": [
-          [
-            {
-              "node": "GitHub13",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub13": {
-        "main": [
-          [
-            {
-              "node": "GitHub14",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub16": {
-        "main": [
-          [
-            {
-              "node": "GitHub17",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub18": {
-        "main": [
-          [
-            {
-              "node": "GitHub19",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub19": {
-        "main": [
-          [
-            {
-              "node": "GitHub20",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "GitHub20": {
-        "main": [
-          [
-            {
-              "node": "GitHub21",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
+      "name": "GitHub",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        620,
+        300
+      ],
+      "credentials": {
+        "githubApi": "Github creds"
       }
     },
-    "createdAt": "2021-02-18T10:30:52.070Z",
-    "updatedAt": "2021-02-18T13:22:45.690Z",
-    "settings": {},
-    "staticData": null
-  }
-]
+    {
+      "parameters": {
+        "resource": "repository",
+        "operation": "getLicense",
+        "owner": "nodemationqa",
+        "repository": "nodeQA"
+      },
+      "name": "GitHub1",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        770,
+        300
+      ],
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "repository",
+        "operation": "listPopularPaths",
+        "owner": "nodemationqa",
+        "repository": "nodeQA"
+      },
+      "name": "GitHub2",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        920,
+        300
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "repository",
+        "operation": "listReferrers",
+        "owner": "nodemationqa",
+        "repository": "nodeQA"
+      },
+      "name": "GitHub3",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        300
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "repository",
+        "operation": "get",
+        "owner": "nodemationqa",
+        "repository": "nodeQA"
+      },
+      "name": "GitHub4",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        470,
+        300
+      ],
+      "executeOnce": false,
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "repository",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "getRepositoryIssuesFilters": {}
+      },
+      "name": "GitHub5",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        1210,
+        300
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "filePath": "testFile",
+        "fileContent": "Test file content, create file operation",
+        "commitMessage": "=Commited {{(new Date()).toGMTString()}}",
+        "additionalParameters": {
+          "branch": {
+            "branch": "main"
+          }
+        }
+      },
+      "name": "GitHub6",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        470,
+        460
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "edit",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "filePath": "testFile",
+        "fileContent": "Updated Test file content, create file operation",
+        "commitMessage": "=Updated commit message {{(new Date()).toGMTString()}}",
+        "additionalParameters": {
+          "branch": {
+            "branch": "main"
+          }
+        }
+      },
+      "name": "GitHub7",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        630,
+        460
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "get",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "filePath": "testFile",
+        "asBinaryProperty": false
+      },
+      "name": "GitHub8",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        770,
+        460
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "delete",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "filePath": "testFile",
+        "commitMessage": "=delete commit message {{(new Date()).toGMTString()}}",
+        "additionalParameters": {
+          "branch": {
+            "branch": "main"
+          }
+        }
+      },
+      "name": "GitHub9",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        910,
+        460
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "title": "=Test Issue created at {{(new Date()).toGMTString()}}",
+        "body": "=Test issue body  {{(new Date()).toGMTString()}}",
+        "labels": [],
+        "assignees": []
+      },
+      "name": "GitHub10",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        470,
+        620
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "createComment",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+        "body": "=Comment on issue at {{(new Date()).toGMTString()}}"
+      },
+      "name": "GitHub11",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        620,
+        620
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "edit",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+        "editFields": {
+          "title": "=Updated {{$node[\"GitHub10\"].json[\"title\"]}}",
+          "body": "=updated Test issue body {{(new Date()).toGMTString()}}"
+        }
+      },
+      "name": "GitHub12",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        770,
+        620
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}"
+      },
+      "name": "GitHub13",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        920,
+        620
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "lock",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+        "lockReason": "spam"
+      },
+      "name": "GitHub14",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        1060,
+        620
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "release",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "releaseTag": "release_test_tag",
+        "additionalFields": {
+          "name": "=Release tag {{(new Date()).toGMTString()}}",
+          "draft": true
+        }
+      },
+      "name": "GitHub15",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        470,
+        770
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "owner": "nodemationqa"
+      },
+      "name": "GitHub16",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        470,
+        930
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "operation": "invite",
+        "organization": "OrgnodeQA",
+        "email": "nodeqa@n8n.io"
+      },
+      "name": "GitHub17",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        660,
+        930
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "review",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "pullRequestNumber": 3,
+        "event": "comment",
+        "body": "=Review Test {{(new Date()).toGMTString()}}",
+        "additionalFields": {}
+      },
+      "name": "GitHub18",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        460,
+        1080
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "review",
+        "operation": "getAll",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "pullRequestNumber": 3,
+        "limit": 1
+      },
+      "name": "GitHub19",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        610,
+        1080
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "review",
+        "operation": "get",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "pullRequestNumber": 3,
+        "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}"
+      },
+      "name": "GitHub20",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        750,
+        1080
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "review",
+        "operation": "update",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "pullRequestNumber": 3,
+        "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}",
+        "body": "=Updated {{$node[\"GitHub18\"].json[\"body\"]}}"
+      },
+      "name": "GitHub21",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        900,
+        1080
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "GitHub4",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "GitHub6",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "GitHub10",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "GitHub15",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "GitHub16",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "GitHub18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub": {
+      "main": [
+        [
+          {
+            "node": "GitHub1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub1": {
+      "main": [
+        [
+          {
+            "node": "GitHub2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub2": {
+      "main": [
+        [
+          {
+            "node": "GitHub3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub3": {
+      "main": [
+        [
+          {
+            "node": "GitHub5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub4": {
+      "main": [
+        [
+          {
+            "node": "GitHub",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub8": {
+      "main": [
+        [
+          {
+            "node": "GitHub9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub6": {
+      "main": [
+        [
+          {
+            "node": "GitHub7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub7": {
+      "main": [
+        [
+          {
+            "node": "GitHub8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub10": {
+      "main": [
+        [
+          {
+            "node": "GitHub11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub11": {
+      "main": [
+        [
+          {
+            "node": "GitHub12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub12": {
+      "main": [
+        [
+          {
+            "node": "GitHub13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub13": {
+      "main": [
+        [
+          {
+            "node": "GitHub14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub16": {
+      "main": [
+        [
+          {
+            "node": "GitHub17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub18": {
+      "main": [
+        [
+          {
+            "node": "GitHub19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub19": {
+      "main": [
+        [
+          {
+            "node": "GitHub20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub20": {
+      "main": [
+        [
+          {
+            "node": "GitHub21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-18T10:30:52.070Z",
+  "updatedAt": "2021-02-18T13:22:45.690Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/39.json
+++ b/workflows/39.json
@@ -1,0 +1,699 @@
+[
+  {
+    "id": 39,
+    "name": "Github:Repository:get getProfile getLicense listPopularPaths listReferrers:File:create edit get delete:Issue:create createComment edit get lock:Release: create:User:getRepositories invite:Review:create getAll get update",
+    "active": false,
+    "nodes": [
+      {
+        "parameters": {},
+        "name": "Start",
+        "type": "n8n-nodes-base.start",
+        "typeVersion": 1,
+        "position": [
+          180,
+          750
+        ]
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "operation": "getProfile",
+          "owner": "nodemationqa",
+          "repository": "nodeQA"
+        },
+        "name": "GitHub",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          620,
+          300
+        ],
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "operation": "getLicense",
+          "owner": "nodemationqa",
+          "repository": "nodeQA"
+        },
+        "name": "GitHub1",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          770,
+          300
+        ],
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "operation": "listPopularPaths",
+          "owner": "nodemationqa",
+          "repository": "nodeQA"
+        },
+        "name": "GitHub2",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          920,
+          300
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "operation": "listReferrers",
+          "owner": "nodemationqa",
+          "repository": "nodeQA"
+        },
+        "name": "GitHub3",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          1070,
+          300
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "operation": "get",
+          "owner": "nodemationqa",
+          "repository": "nodeQA"
+        },
+        "name": "GitHub4",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          470,
+          300
+        ],
+        "executeOnce": false,
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "repository",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "getRepositoryIssuesFilters": {}
+        },
+        "name": "GitHub5",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          1210,
+          300
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        },
+        "disabled": true
+      },
+      {
+        "parameters": {
+          "resource": "file",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "filePath": "testFile",
+          "fileContent": "Test file content, create file operation",
+          "commitMessage": "=Commited {{(new Date()).toGMTString()}}",
+          "additionalParameters": {
+            "branch": {
+              "branch": "main"
+            }
+          }
+        },
+        "name": "GitHub6",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          470,
+          460
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "file",
+          "operation": "edit",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "filePath": "testFile",
+          "fileContent": "Updated Test file content, create file operation",
+          "commitMessage": "=Updated commit message {{(new Date()).toGMTString()}}",
+          "additionalParameters": {
+            "branch": {
+              "branch": "main"
+            }
+          }
+        },
+        "name": "GitHub7",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          630,
+          460
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "file",
+          "operation": "get",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "filePath": "testFile",
+          "asBinaryProperty": false
+        },
+        "name": "GitHub8",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          770,
+          460
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "file",
+          "operation": "delete",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "filePath": "testFile",
+          "commitMessage": "=delete commit message {{(new Date()).toGMTString()}}",
+          "additionalParameters": {
+            "branch": {
+              "branch": "main"
+            }
+          }
+        },
+        "name": "GitHub9",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          910,
+          460
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "title": "=Test Issue created at {{(new Date()).toGMTString()}}",
+          "body": "=Test issue body  {{(new Date()).toGMTString()}}",
+          "labels": [],
+          "assignees": []
+        },
+        "name": "GitHub10",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          470,
+          620
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "operation": "createComment",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+          "body": "=Comment on issue at {{(new Date()).toGMTString()}}"
+        },
+        "name": "GitHub11",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          620,
+          620
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "operation": "edit",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+          "editFields": {
+            "title": "=Updated {{$node[\"GitHub10\"].json[\"title\"]}}",
+            "body": "=updated Test issue body {{(new Date()).toGMTString()}}"
+          }
+        },
+        "name": "GitHub12",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          770,
+          620
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "operation": "get",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}"
+        },
+        "name": "GitHub13",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          920,
+          620
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "operation": "lock",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "issueNumber": "={{$node[\"GitHub10\"].json[\"number\"]}}",
+          "lockReason": "spam"
+        },
+        "name": "GitHub14",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          1060,
+          620
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "release",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "releaseTag": "release_test_tag",
+          "additionalFields": {
+            "name": "=Release tag {{(new Date()).toGMTString()}}",
+            "draft": true
+          }
+        },
+        "name": "GitHub15",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          470,
+          770
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "user",
+          "owner": "nodemationqa"
+        },
+        "name": "GitHub16",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          470,
+          930
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "user",
+          "operation": "invite",
+          "organization": "OrgnodeQA",
+          "email": "nodeqa@n8n.io"
+        },
+        "name": "GitHub17",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          660,
+          930
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "review",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "pullRequestNumber": 3,
+          "event": "comment",
+          "body": "=Review Test {{(new Date()).toGMTString()}}",
+          "additionalFields": {}
+        },
+        "name": "GitHub18",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          460,
+          1080
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "review",
+          "operation": "getAll",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "pullRequestNumber": 3,
+          "limit": 1
+        },
+        "name": "GitHub19",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          610,
+          1080
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "review",
+          "operation": "get",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "pullRequestNumber": 3,
+          "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}"
+        },
+        "name": "GitHub20",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          750,
+          1080
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      },
+      {
+        "parameters": {
+          "resource": "review",
+          "operation": "update",
+          "owner": "nodemationqa",
+          "repository": "nodeQA",
+          "pullRequestNumber": 3,
+          "reviewId": "={{$node[\"GitHub18\"].json[\"id\"]}}",
+          "body": "=Updated {{$node[\"GitHub18\"].json[\"body\"]}}"
+        },
+        "name": "GitHub21",
+        "type": "n8n-nodes-base.github",
+        "typeVersion": 1,
+        "position": [
+          900,
+          1080
+        ],
+        "alwaysOutputData": true,
+        "credentials": {
+          "githubApi": "Github creds"
+        }
+      }
+    ],
+    "connections": {
+      "Start": {
+        "main": [
+          [
+            {
+              "node": "GitHub4",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "GitHub6",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "GitHub10",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "GitHub15",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "GitHub16",
+              "type": "main",
+              "index": 0
+            },
+            {
+              "node": "GitHub18",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub": {
+        "main": [
+          [
+            {
+              "node": "GitHub1",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub1": {
+        "main": [
+          [
+            {
+              "node": "GitHub2",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub2": {
+        "main": [
+          [
+            {
+              "node": "GitHub3",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub3": {
+        "main": [
+          [
+            {
+              "node": "GitHub5",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub4": {
+        "main": [
+          [
+            {
+              "node": "GitHub",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub8": {
+        "main": [
+          [
+            {
+              "node": "GitHub9",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub6": {
+        "main": [
+          [
+            {
+              "node": "GitHub7",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub7": {
+        "main": [
+          [
+            {
+              "node": "GitHub8",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub10": {
+        "main": [
+          [
+            {
+              "node": "GitHub11",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub11": {
+        "main": [
+          [
+            {
+              "node": "GitHub12",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub12": {
+        "main": [
+          [
+            {
+              "node": "GitHub13",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub13": {
+        "main": [
+          [
+            {
+              "node": "GitHub14",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub16": {
+        "main": [
+          [
+            {
+              "node": "GitHub17",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub18": {
+        "main": [
+          [
+            {
+              "node": "GitHub19",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub19": {
+        "main": [
+          [
+            {
+              "node": "GitHub20",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "GitHub20": {
+        "main": [
+          [
+            {
+              "node": "GitHub21",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "createdAt": "2021-02-18T10:30:52.070Z",
+    "updatedAt": "2021-02-18T13:22:45.690Z",
+    "settings": {},
+    "staticData": null
+  }
+]


### PR DESCRIPTION
This PR includes a workflow to test the Github node

Workflow n°39 support:

- Repository: get getProfile getLicense listPopularPaths listReferrers
- File: create edit get delete
- Issue: create createComment edit get lock
- Release: create
- User: getRepositories invite
- Review: create getAll get update

Note: The node (Repository, listIssues) is deactivated because of missing query limit feature