### PR TITLE
Add test workflow for Clockify node

### DIFF
--- a/workflows/51.json
+++ b/workflows/51.json
@@ -1,0 +1,397 @@
+{
+  "id": 51,
+  "name": "Clockify:Project:create update get getAll:Tag:create update getAll delete:TimeEntry:create update get delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        290,
+        420
+      ]
+    },
+    {
+      "parameters": {
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "name": "=TestProject created {{(new Date).toGMTString()}}",
+        "additionalFields": {}
+      },
+      "name": "Clockify",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        500,
+        250
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "projectId": "={{$node[\"Clockify\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "=Updated {{$node[\"Clockify\"].json[\"name\"]}}"
+        }
+      },
+      "name": "Clockify1",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        650,
+        250
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "projectId": "={{$node[\"Clockify\"].json[\"id\"]}}"
+      },
+      "name": "Clockify2",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        800,
+        250
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "limit": 1,
+        "additionalFields": {}
+      },
+      "name": "Clockify3",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        950,
+        250
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "projectId": "={{$node[\"Clockify\"].json[\"id\"]}}"
+      },
+      "name": "Clockify4",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        250
+      ],
+      "notesInFlow": true,
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      },
+      "disabled": true,
+      "notes": "delete require archive first"
+    },
+    {
+      "parameters": {
+        "resource": "tag",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "name": "TestTag"
+      },
+      "name": "Clockify5",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        500,
+        400
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "tag",
+        "operation": "update",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "tagId": "={{$node[\"Clockify5\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "UpdatedTag"
+        }
+      },
+      "name": "Clockify6",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        650,
+        400
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "tag",
+        "operation": "getAll",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "limit": 1,
+        "additionalFields": {}
+      },
+      "name": "Clockify7",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        800,
+        400
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "tag",
+        "operation": "delete",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "tagId": "={{$node[\"Clockify5\"].json[\"id\"]}}"
+      },
+      "name": "Clockify8",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        950,
+        400
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "timeEntry",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "start": "={{(new Date()).toISOString()}}",
+        "additionalFields": {}
+      },
+      "name": "Clockify9",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        500,
+        560
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "timeEntry",
+        "operation": "update",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "timeEntryId": "={{$node[\"Clockify9\"].json[\"id\"]}}",
+        "updateFields": {
+          "description": "Updated time entry"
+        }
+      },
+      "name": "Clockify10",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        650,
+        560
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "timeEntry",
+        "operation": "get",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "timeEntryId": "={{$node[\"Clockify9\"].json[\"id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "Clockify11",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        800,
+        560
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "timeEntry",
+        "operation": "delete",
+        "workspaceId": "60335ad3f24e660123d7fdee",
+        "timeEntryId": "={{$node[\"Clockify9\"].json[\"id\"]}}"
+      },
+      "name": "Clockify12",
+      "type": "n8n-nodes-base.clockify",
+      "typeVersion": 1,
+      "position": [
+        950,
+        560
+      ],
+      "credentials": {
+        "clockifyApi": "Clockify creds"
+      }
+    }
+  ],
+  "connections": {
+    "Clockify": {
+      "main": [
+        [
+          {
+            "node": "Clockify1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify1": {
+      "main": [
+        [
+          {
+            "node": "Clockify2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify2": {
+      "main": [
+        [
+          {
+            "node": "Clockify3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify3": {
+      "main": [
+        [
+          {
+            "node": "Clockify4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify5": {
+      "main": [
+        [
+          {
+            "node": "Clockify6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify6": {
+      "main": [
+        [
+          {
+            "node": "Clockify7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify7": {
+      "main": [
+        [
+          {
+            "node": "Clockify8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify9": {
+      "main": [
+        [
+          {
+            "node": "Clockify10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify10": {
+      "main": [
+        [
+          {
+            "node": "Clockify11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clockify11": {
+      "main": [
+        [
+          {
+            "node": "Clockify12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Clockify",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Clockify5",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Clockify9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-22T07:24:58.045Z",
+  "updatedAt": "2021-02-22T08:49:36.716Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This PR includes a workflow to test the Clockify node

Workflow n°51 support:

- Project: create update get getAll
- Tag: create update getAll delete
- TimeEntry: create update get delete

Note: this workflow doesn't support delete project (the project must be archived before deletion)