### PR TITLE
Add test workflow for Contentful node

### DIFF
--- a/workflows/70.json
+++ b/workflows/70.json
@@ -1,0 +1,194 @@
+{
+  "id": 70,
+  "name": "Contentful-delivery-api:locale:getAll:entry:getAll:ContentType:get:Asset:getAll get:Space:get",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        260,
+        390
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "additionalFields": {
+          "content_type": "blogPost"
+        }
+      },
+      "name": "Contentful",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        550,
+        250
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contentType",
+        "contentTypeId": "blogPost",
+        "additionalFields": {}
+      },
+      "name": "Contentful1",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        550,
+        420
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "asset",
+        "limit": 1,
+        "additionalFields": {}
+      },
+      "name": "Contentful2",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        550,
+        570
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "asset",
+        "operation": "get",
+        "assetId": "5UvpPFo279OoVXHLRXqlo9"
+      },
+      "name": "Contentful3",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        700,
+        570
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "entryId": "={{$node[\"Contentful\"].json[\"author\"][\"sys\"][\"id\"]}}"
+      },
+      "name": "Contentful4",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        700,
+        250
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "locale",
+        "limit": 1
+      },
+      "name": "Contentful5",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        550,
+        100
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "space"
+      },
+      "name": "Contentful6",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        550,
+        730
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    }
+  ],
+  "connections": {
+    "Contentful": {
+      "main": [
+        [
+          {
+            "node": "Contentful4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Contentful2": {
+      "main": [
+        [
+          {
+            "node": "Contentful3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Contentful5",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-25T13:38:22.940Z",
+  "updatedAt": "2021-02-25T13:38:22.940Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/71.json
+++ b/workflows/71.json
@@ -1,0 +1,201 @@
+{
+  "id": 71,
+  "name": "Contentful-preview-api:locale:getAll:entry:getAll:ContentType:get:Asset:getAll get:Space:get",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        300,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "operation": "getAll",
+        "limit": 1,
+        "additionalFields": {
+          "content_type": "blogPost"
+        }
+      },
+      "name": "Contentful",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        510,
+        130
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "resource": "contentType",
+        "contentTypeId": "blogPost",
+        "additionalFields": {}
+      },
+      "name": "Contentful1",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        510,
+        450
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "resource": "asset",
+        "limit": 1,
+        "additionalFields": {}
+      },
+      "name": "Contentful2",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        510,
+        300
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "resource": "asset",
+        "operation": "get",
+        "assetId": "5UvpPFo279OoVXHLRXqlo9"
+      },
+      "name": "Contentful3",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        650,
+        300
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "entryId": "={{$node[\"Contentful\"].json[\"author\"][\"sys\"][\"id\"]}}"
+      },
+      "name": "Contentful4",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        660,
+        130
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "resource": "locale",
+        "limit": 1
+      },
+      "name": "Contentful5",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        510,
+        750
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    },
+    {
+      "parameters": {
+        "source": "previewApi",
+        "resource": "space"
+      },
+      "name": "Contentful6",
+      "type": "n8n-nodes-base.contentful",
+      "typeVersion": 1,
+      "position": [
+        510,
+        610
+      ],
+      "credentials": {
+        "contentfulApi": "Contenful creds"
+      }
+    }
+  ],
+  "connections": {
+    "Contentful": {
+      "main": [
+        [
+          {
+            "node": "Contentful4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Contentful2": {
+      "main": [
+        [
+          {
+            "node": "Contentful3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Contentful1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful5",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Contentful6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-25T13:44:10.456Z",
+  "updatedAt": "2021-02-25T13:44:14.960Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This PR includes a workflow to test the Contentful node

Workflows n°70 & n°71 support the same functionalities for delivery & preview APIS:

- locale: getAll
- entry: getAll
- ContentType: get
- Asset: getAll get
- Space: get

Note: both workflows doesn't support get Entry & get Asset (a bug in the node code)