### PR TITLE
Add test workflow for Zulip node

### DIFF
--- a/workflows/72.json
+++ b/workflows/72.json
@@ -1,0 +1,525 @@
+{
+  "id": 72,
+  "name": "Zulip:Message:sendPrivate update updateFile sendStream get delete:Stream:create getAll getSubscribed update delete:user:getAll get update",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        460
+      ]
+    },
+    {
+      "parameters": {
+        "to": [
+          "nodeqa@n8n.io"
+        ],
+        "content": "=Message {{Date.now()}}"
+      },
+      "name": "Zulip",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        430,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "messageId": "={{$node[\"Zulip\"].json[\"id\"]}}",
+        "updateFields": {
+          "content": "=Update content {{Date.now()}}"
+        }
+      },
+      "name": "Zulip1",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        590,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "sendStream",
+        "stream": 278954,
+        "topic": "topic demonstration",
+        "content": "Test Stream message {{Date.now()}}"
+      },
+      "name": "Zulip2",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        740,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "messageId": "={{$node[\"Zulip\"].json[\"id\"]}}"
+      },
+      "name": "Zulip3",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        890,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "messageId": "={{$node[\"Zulip\"].json[\"id\"]}}"
+      },
+      "name": "Zulip4",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        1040,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "messageId": "={{$node[\"Zulip2\"].json[\"id\"]}}"
+      },
+      "name": "Zulip5",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        300
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "updateFile"
+      },
+      "name": "Zulip6",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        590,
+        470
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "filePath": "../../../assets/n8n-logo.png"
+      },
+      "name": "Read Binary File",
+      "type": "n8n-nodes-base.readBinaryFile",
+      "typeVersion": 1,
+      "position": [
+        430,
+        470
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "stream",
+        "subscriptions": {
+          "properties": [
+            {
+              "name": "StreamTest",
+              "description": "testing stream from n8n"
+            }
+          ]
+        },
+        "additionalFields": {}
+      },
+      "name": "Zulip7",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        430,
+        620
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "stream",
+        "operation": "getAll",
+        "additionalFields": {
+          "includeAllActive": false,
+          "includeDefault": false,
+          "includePublic": false
+        }
+      },
+      "name": "Zulip8",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        600,
+        620
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "stream",
+        "operation": "update",
+        "streamId": "={{$node[\"Function\"].json[\"stream_id\"]}}",
+        "additionalFields": {
+          "newName": "=UpdateStream{{Date.now()}}"
+        }
+      },
+      "name": "Zulip9",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        910,
+        620
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "functionCode": "\nreturn [items[0]];"
+      },
+      "name": "Function",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        750,
+        620
+      ],
+      "notesInFlow": true,
+      "notes": "Convert multiple result into one"
+    },
+    {
+      "parameters": {
+        "resource": "stream",
+        "operation": "getSubscribed",
+        "additionalFields": {}
+      },
+      "name": "Zulip10",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        590,
+        760
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "stream",
+        "operation": "delete",
+        "streamId": "={{$node[\"Function\"].json[\"stream_id\"]}}"
+      },
+      "name": "Zulip11",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        620
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "operation": "getAll",
+        "additionalFields": {}
+      },
+      "name": "Zulip12",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        440,
+        910
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "operation": "get",
+        "userId": "={{$node[\"Zulip12\"].json[\"user_id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "Zulip13",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        590,
+        910
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "operation": "update",
+        "userId": "={{$node[\"Zulip12\"].json[\"user_id\"]}}",
+        "additionalFields": {
+          "fullName": "nodequpdated"
+        }
+      },
+      "name": "Zulip14",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        750,
+        910
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "operation": "update",
+        "userId": "={{$node[\"Zulip12\"].json[\"user_id\"]}}",
+        "additionalFields": {
+          "fullName": "nodeqa"
+        }
+      },
+      "name": "Zulip15",
+      "type": "n8n-nodes-base.zulip",
+      "typeVersion": 1,
+      "position": [
+        890,
+        910
+      ],
+      "credentials": {
+        "zulipApi": "Zulip creds"
+      }
+    }
+  ],
+  "connections": {
+    "Zulip": {
+      "main": [
+        [
+          {
+            "node": "Zulip1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip1": {
+      "main": [
+        [
+          {
+            "node": "Zulip2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip2": {
+      "main": [
+        [
+          {
+            "node": "Zulip3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip3": {
+      "main": [
+        [
+          {
+            "node": "Zulip4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip4": {
+      "main": [
+        [
+          {
+            "node": "Zulip5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip6": {
+      "main": [
+        []
+      ]
+    },
+    "Read Binary File": {
+      "main": [
+        [
+          {
+            "node": "Zulip6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Read Binary File",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Zulip",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Zulip7",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Zulip12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip7": {
+      "main": [
+        [
+          {
+            "node": "Zulip8",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Zulip10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip8": {
+      "main": [
+        [
+          {
+            "node": "Function",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Function": {
+      "main": [
+        [
+          {
+            "node": "Zulip9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip9": {
+      "main": [
+        [
+          {
+            "node": "Zulip11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip12": {
+      "main": [
+        [
+          {
+            "node": "Zulip13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip13": {
+      "main": [
+        [
+          {
+            "node": "Zulip14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip14": {
+      "main": [
+        [
+          {
+            "node": "Zulip15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Zulip15": {
+      "main": [
+        []
+      ]
+    }
+  },
+  "createdAt": "2021-02-25T14:32:07.257Z",
+  "updatedAt": "2021-02-25T14:33:34.642Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This PR includes a workflow to test the Zulip node

Workflow n°72 support:

- Message: sendPrivate, update, updateFile, sendStream, get, delete
- Stream: create, getAll, getSubscribed, update, delete
- User: getAll, get, update

Note: this workflow doesn't support create User (not permissioned) & deactivate User (to mitigate the problem of having 0 user active)