### PR TITLE
Add test workflows for Harvest node

### DIFF
--- a/workflows/75.json
+++ b/workflows/75.json
@@ -1,0 +1,504 @@
+{
+  "id": 75,
+  "name": "Harvest:Client:create update getAll get delete:Invoice:create update getAll get delete:Contact:create update get getAll delete:Company:get",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        150,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "create",
+        "name": "=Client{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Harvest",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        230
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "=UpdatedClient{{Date.now()}}"
+        }
+      },
+      "name": "Harvest1",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1310,
+        230
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest2",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1460,
+        230
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest\"].json[\"id\"]}}"
+      },
+      "name": "Harvest3",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1610,
+        230
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest\"].json[\"id\"]}}"
+      },
+      "name": "Harvest4",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1760,
+        230
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "company",
+        "accountId": 1416330
+      },
+      "name": "Harvest5",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        440
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "contact",
+        "accountId": 1416330,
+        "operation": "create",
+        "firstName": "=FirstName{{Date.now()}}",
+        "clientId": "={{$node[\"Harvest\"].json[\"id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "Harvest6",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "contact",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest6\"].json[\"id\"]}}",
+        "updateFields": {
+          "first_name": "=FirstNameUpdated{{Date.now()}}"
+        }
+      },
+      "name": "Harvest7",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        700,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "contact",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest6\"].json[\"id\"]}}"
+      },
+      "name": "Harvest8",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        850,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "contact",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest9",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "contact",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest6\"].json[\"id\"]}}"
+      },
+      "name": "Harvest10",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "invoice",
+        "accountId": 1416330,
+        "operation": "create",
+        "clientId": "={{$node[\"Harvest\"].json[\"id\"]}}",
+        "additionalFields": {
+          "subject": "=Subject{{Date.now()}}"
+        }
+      },
+      "name": "Harvest11",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        140
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "invoice",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}",
+        "updateFields": {
+          "subject": "=UpdatedSubject{{Date.now()}}"
+        }
+      },
+      "name": "Harvest12",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        700,
+        140
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "invoice",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest13",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        850,
+        140
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "invoice",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}"
+      },
+      "name": "Harvest14",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        140
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "invoice",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}"
+      },
+      "name": "Harvest15",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        140
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    }
+  ],
+  "connections": {
+    "Harvest": {
+      "main": [
+        [
+          {
+            "node": "Harvest11",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest1": {
+      "main": [
+        [
+          {
+            "node": "Harvest2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest2": {
+      "main": [
+        [
+          {
+            "node": "Harvest3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest3": {
+      "main": [
+        [
+          {
+            "node": "Harvest4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Harvest",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest6": {
+      "main": [
+        [
+          {
+            "node": "Harvest7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest7": {
+      "main": [
+        [
+          {
+            "node": "Harvest8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest8": {
+      "main": [
+        [
+          {
+            "node": "Harvest9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest9": {
+      "main": [
+        [
+          {
+            "node": "Harvest10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest10": {
+      "main": [
+        [
+          {
+            "node": "Harvest1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest11": {
+      "main": [
+        [
+          {
+            "node": "Harvest12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest12": {
+      "main": [
+        [
+          {
+            "node": "Harvest13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest13": {
+      "main": [
+        [
+          {
+            "node": "Harvest14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest14": {
+      "main": [
+        [
+          {
+            "node": "Harvest15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-26T09:26:39.448Z",
+  "updatedAt": "2021-02-26T10:58:10.897Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/76.json
+++ b/workflows/76.json
@@ -1,0 +1,648 @@
+{
+  "id": 76,
+  "name": "Harvest:Project:create update getAll get delete:Task:getAll get:TimeEntry:createByDuration createByStartEnd update getAll restartTime stopTime delete:User:me get getAll update",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        160,
+        650
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "create",
+        "name": "=RandomClient{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Harvest",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest\"].json[\"id\"]}}"
+      },
+      "name": "Harvest1",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1300,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "project",
+        "accountId": 1416330,
+        "operation": "create",
+        "name": "=Project{{Date.now()}}",
+        "clientId": "={{$node[\"Harvest\"].json[\"id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "Harvest2",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        350
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "project",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}",
+        "updateFields": {}
+      },
+      "name": "Harvest3",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        700,
+        350
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "project",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest4",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        850,
+        350
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "project",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}"
+      },
+      "name": "Harvest5",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        350
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "project",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}"
+      },
+      "name": "Harvest6",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        350
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest7",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        500
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest7\"].json[\"id\"]}}"
+      },
+      "name": "Harvest8",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        500
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "createByDuration",
+        "projectId": "27925524",
+        "taskId": "16181821",
+        "spentDate": "2021-02-26T10:20:56.825Z",
+        "additionalFields": {}
+      },
+      "name": "Harvest11",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}",
+        "updateFields": {}
+      },
+      "name": "Harvest12",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest13",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        700,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "restartTime",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}"
+      },
+      "name": "Harvest14",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        850,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "stopTime",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}"
+      },
+      "name": "Harvest15",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest11\"].json[\"id\"]}}"
+      },
+      "name": "Harvest16",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        650
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "createByStartEnd",
+        "projectId": "27925524",
+        "taskId": "16181821",
+        "spentDate": "2021-02-26T10:20:56.825Z",
+        "additionalFields": {
+          "ended_time": "5:00pm",
+          "started_time": "8:00am"
+        }
+      },
+      "name": "Harvest17",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        800
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "timeEntry",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest17\"].json[\"id\"]}}"
+      },
+      "name": "Harvest18",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        800
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "user",
+        "accountId": 1416330
+      },
+      "name": "Harvest19",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        400,
+        950
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "user",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest19\"].json[\"id\"]}}"
+      },
+      "name": "Harvest20",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        550,
+        950
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "user",
+        "accountId": 1416330,
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest21",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        700,
+        950
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "user",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest19\"].json[\"id\"]}}",
+        "updateFields": {
+          "timezone": "Berlin"
+        }
+      },
+      "name": "Harvest22",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        850,
+        950
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Harvest",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest11",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest17",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest7",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest": {
+      "main": [
+        [
+          {
+            "node": "Harvest2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest2": {
+      "main": [
+        [
+          {
+            "node": "Harvest3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest3": {
+      "main": [
+        [
+          {
+            "node": "Harvest4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest4": {
+      "main": [
+        [
+          {
+            "node": "Harvest5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest5": {
+      "main": [
+        [
+          {
+            "node": "Harvest6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest6": {
+      "main": [
+        [
+          {
+            "node": "Harvest1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest7": {
+      "main": [
+        [
+          {
+            "node": "Harvest8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest11": {
+      "main": [
+        [
+          {
+            "node": "Harvest12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest12": {
+      "main": [
+        [
+          {
+            "node": "Harvest13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest13": {
+      "main": [
+        [
+          {
+            "node": "Harvest14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest14": {
+      "main": [
+        [
+          {
+            "node": "Harvest15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest15": {
+      "main": [
+        [
+          {
+            "node": "Harvest16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest17": {
+      "main": [
+        [
+          {
+            "node": "Harvest18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest19": {
+      "main": [
+        [
+          {
+            "node": "Harvest20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest20": {
+      "main": [
+        [
+          {
+            "node": "Harvest21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest21": {
+      "main": [
+        [
+          {
+            "node": "Harvest22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest8": {
+      "main": [
+        []
+      ]
+    }
+  },
+  "createdAt": "2021-02-26T09:54:20.362Z",
+  "updatedAt": "2021-02-26T11:01:07.014Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/77.json
+++ b/workflows/77.json
@@ -1,0 +1,392 @@
+{
+  "id": 77,
+  "name": "Harvest:Expense:create update get getAll delete:Estimate:create update get getAll delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        220
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "create",
+        "name": "=Client{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Harvest",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "client",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest\"].json[\"id\"]}}"
+      },
+      "name": "Harvest1",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1340,
+        300
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "estimate",
+        "accountId": 1416330,
+        "operation": "create",
+        "clientId": "={{$node[\"Harvest\"].json[\"id\"]}}",
+        "additionalFields": {
+          "subject": "=Estimate{{Date.now()}}"
+        }
+      },
+      "name": "Harvest2",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        600,
+        400
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "estimate",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}",
+        "updateFields": {
+          "subject": "=UpdateSubject{{Date.now()}}"
+        }
+      },
+      "name": "Harvest3",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        750,
+        400
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "estimate",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}"
+      },
+      "name": "Harvest4",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        900,
+        400
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "estimate",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest5",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        400
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "estimate",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest2\"].json[\"id\"]}}"
+      },
+      "name": "Harvest6",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        400
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "expense",
+        "accountId": 1416330,
+        "operation": "create",
+        "projectId": "27925524",
+        "expenseCategoryId": "7737171",
+        "spentDate": "2021-02-26T10:51:40.112Z",
+        "additionalFields": {
+          "total_cost": "101"
+        }
+      },
+      "name": "Harvest7",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        460,
+        150
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "expense",
+        "accountId": 1416330,
+        "operation": "update",
+        "id": "={{$node[\"Harvest7\"].json[\"id\"]}}",
+        "updateFields": {
+          "total_cost": "201"
+        }
+      },
+      "name": "Harvest8",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        600,
+        150
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "expense",
+        "accountId": 1416330,
+        "operation": "get",
+        "id": "={{$node[\"Harvest7\"].json[\"id\"]}}"
+      },
+      "name": "Harvest9",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        750,
+        150
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "expense",
+        "accountId": 1416330,
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Harvest10",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        900,
+        150
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "expense",
+        "accountId": 1416330,
+        "operation": "delete",
+        "id": "={{$node[\"Harvest7\"].json[\"id\"]}}"
+      },
+      "name": "Harvest11",
+      "type": "n8n-nodes-base.harvest",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        150
+      ],
+      "credentials": {
+        "harvestOAuth2Api": "Harvest OAuth2 creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Harvest",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Harvest7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest": {
+      "main": [
+        [
+          {
+            "node": "Harvest2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest2": {
+      "main": [
+        [
+          {
+            "node": "Harvest3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest3": {
+      "main": [
+        [
+          {
+            "node": "Harvest4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest4": {
+      "main": [
+        [
+          {
+            "node": "Harvest5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest5": {
+      "main": [
+        [
+          {
+            "node": "Harvest6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest6": {
+      "main": [
+        [
+          {
+            "node": "Harvest1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest7": {
+      "main": [
+        [
+          {
+            "node": "Harvest8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest8": {
+      "main": [
+        [
+          {
+            "node": "Harvest9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest9": {
+      "main": [
+        [
+          {
+            "node": "Harvest10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Harvest10": {
+      "main": [
+        [
+          {
+            "node": "Harvest11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-26T10:47:07.557Z",
+  "updatedAt": "2021-02-26T10:54:33.074Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes 3 workflows to test the Harvest node

Workflow n°75 support:

- Client: create update getAll get delete
- Invoice: create update getAll get delete
- Contact: create update get getAll delete
- Company: get

Workflow n°76 support:

- Project: create update getAll get delete
- Task: getAll get
- TimeEntry: createByDuration createByStartEnd update getAll restartTime stopTime delete
- User: me get getAll update

note:  workflow 76 doesn't support Task: create, update & delete (node bug) and User: create delete (because of the free plan limits to 1 single user)

Workflow n°77 support:

- Expense: create update get getAll delete
- Estimate: create update get getAll delete
