### PR TITLE
Add test workflow for Google Drive node

### DIFF
--- a/workflows/44.json
+++ b/workflows/44.json
@@ -1,0 +1,339 @@
+{
+  "id": 44,
+  "name": "GoogleDrive:Folder:create share delete:File:upload share list download copy delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "folder",
+        "name": "testFolder"
+      },
+      "name": "Google Drive",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        290
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "folder",
+        "operation": "share",
+        "fileId": "={{$node[\"Google Drive\"].json[\"id\"]}}",
+        "permissionsUi": {
+          "permissionsValues": {
+            "role": "reader",
+            "type": "anyone"
+          }
+        },
+        "options": {}
+      },
+      "name": "Google Drive1",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        670,
+        290
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "folder",
+        "operation": "delete",
+        "fileId": "={{$node[\"Google Drive\"].json[\"id\"]}}"
+      },
+      "name": "Google Drive2",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        830,
+        290
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "fileContent": "Test File Content",
+        "name": "testFile",
+        "parents": []
+      },
+      "name": "Google Drive3",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "share",
+        "fileId": "={{$node[\"Google Drive3\"].json[\"id\"]}}",
+        "permissionsUi": {
+          "permissionsValues": {
+            "role": "reader",
+            "type": "anyone"
+          }
+        },
+        "options": {}
+      },
+      "name": "Google Drive4",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        650,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "list",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Google Drive5",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "download",
+        "fileId": "={{$node[\"Google Drive3\"].json[\"id\"]}}"
+      },
+      "name": "Google Drive6",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        960,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "copy",
+        "fileId": "={{$node[\"Google Drive3\"].json[\"id\"]}}",
+        "options": {}
+      },
+      "name": "Google Drive7",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "delete",
+        "fileId": "={{$node[\"Google Drive3\"].json[\"id\"]}}"
+      },
+      "name": "Google Drive8",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        1240,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "operation": "delete",
+        "fileId": "={{$node[\"Google Drive7\"].json[\"id\"]}}"
+      },
+      "name": "Google Drive9",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        1380,
+        450
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      }
+    },
+    {
+      "parameters": {
+        "authentication": "oAuth2",
+        "resource": "drive",
+        "options": {}
+      },
+      "name": "Google Drive10",
+      "type": "n8n-nodes-base.googleDrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        610
+      ],
+      "credentials": {
+        "googleDriveOAuth2Api": "Google Drive creds"
+      },
+      "disabled": true
+    }
+  ],
+  "connections": {
+    "Google Drive": {
+      "main": [
+        [
+          {
+            "node": "Google Drive1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive1": {
+      "main": [
+        [
+          {
+            "node": "Google Drive2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Google Drive",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Google Drive3",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Google Drive10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive3": {
+      "main": [
+        [
+          {
+            "node": "Google Drive4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive4": {
+      "main": [
+        [
+          {
+            "node": "Google Drive5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive5": {
+      "main": [
+        [
+          {
+            "node": "Google Drive6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive6": {
+      "main": [
+        [
+          {
+            "node": "Google Drive7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive7": {
+      "main": [
+        [
+          {
+            "node": "Google Drive8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Google Drive8": {
+      "main": [
+        [
+          {
+            "node": "Google Drive9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-02-19T07:45:12.148Z",
+  "updatedAt": "2021-02-26T12:22:54.085Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Google Drive node

Workflow n°44 support:

- Folder: create share delete
- File: upload share list download copy delete

Note: this workflow doesn't support the `Drive` resource (require Google workspace permission)