### PR TITLE
Add test workflow for Date&Time node

### DIFF
--- a/workflows/90.json
+++ b/workflows/90.json
@@ -1,0 +1,207 @@
+{
+  "id": 90,
+  "name": "Date&Time:formatDate",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        400,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "toFormat": "YYYY/MM/DD",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time1",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        550,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "toFormat": "MMMM DD YYYY",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time2",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        700,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "toFormat": "MM-DD-YYYY",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time3",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        850,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "toFormat": "YYYY-MM-DD",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time4",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "value": "1614764492648",
+        "toFormat": "X",
+        "options": {
+          "fromFormat": "x"
+        }
+      },
+      "name": "Date & Time5",
+      "type": "n8n-nodes-base.dateTime",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "\n// mm/dd/yyyy\nif($node[\"Date & Time\"].json[\"data\"] !== \"03/03/2021\")\n{\n    throw new Error(\"Error convert date to mm/dd/yyyy\");\n}\n// yyyy/mm/dd\nif($node[\"Date & Time1\"].json[\"data\"] !== \"2021/03/03\")\n{\n    throw new Error(\"Error convert date to yyyy/mm/dd\");\n}\n// mmmm dd yyyy\nif($node[\"Date & Time2\"].json[\"data\"] !== \"March 03 2021\")\n{\n    throw new Error(\"Error convert date to mmmm dd yyyy\");\n}\n// mm-dd-yyyy\nif($node[\"Date & Time3\"].json[\"data\"] !== \"03-03-2021\")\n{\n    throw new Error(\"Error convert date to mm-dd-yyyy\");\n}\n// yyyy-mm-dd\nif($node[\"Date & Time4\"].json[\"data\"] !== \"2021-03-03\")\n{   \n    throw new Error(\"Error convert date to yyyy-mm-dd\");\n}\n// unix timestamp\nif($node[\"Date & Time5\"].json[\"data\"] !== \"1614764492\")\n{   \n    throw new Error(\"Error convert date to unix timestamp\");\n}\nreturn items;"
+      },
+      "name": "Function",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Date & Time": {
+      "main": [
+        [
+          {
+            "node": "Date & Time1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Date & Time1": {
+      "main": [
+        [
+          {
+            "node": "Date & Time2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Date & Time2": {
+      "main": [
+        [
+          {
+            "node": "Date & Time3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Date & Time3": {
+      "main": [
+        [
+          {
+            "node": "Date & Time4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Date & Time4": {
+      "main": [
+        [
+          {
+            "node": "Date & Time5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Date & Time5": {
+      "main": [
+        [
+          {
+            "node": "Function",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Date & Time",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-03T09:55:59.197Z",
+  "updatedAt": "2021-03-03T09:56:30.684Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Date&Time node

Workflow n°90 support the operation `formatDate` with different `toFormat`

Note: this workflow uses a static data as date input.