### PR TITLE
Add test workflows for Rename Keys node

### DIFF
--- a/workflows/101.json
+++ b/workflows/101.json
@@ -1,0 +1,111 @@
+{
+  "id": 101,
+  "name": "RenameKeys",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "keys": {
+          "key": [
+            {
+              "currentKey": "toBeRenamed",
+              "newKey": "Renamed"
+            }
+          ]
+        }
+      },
+      "name": "Rename Keys",
+      "type": "n8n-nodes-base.renameKeys",
+      "typeVersion": 1,
+      "position": [
+        650,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "name",
+              "value": "test"
+            },
+            {
+              "name": "toBeRenamed",
+              "value": "name"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "testData = JSON.stringify(\n{\nname: \"test\",\nRenamed: \"name\"\n}\n)\nif(JSON.stringify($node['Rename Keys'].json) !== testData){\n  throw new Error('Error in rename keys node');\n}\n\nreturn items;"
+      },
+      "name": "Function",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        850,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Rename Keys": {
+      "main": [
+        [
+          {
+            "node": "Function",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set": {
+      "main": [
+        [
+          {
+            "node": "Rename Keys",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Set",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-04T09:49:58.859Z",
+  "updatedAt": "2021-03-04T09:49:58.859Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Rename Keys node

Workflow n°101 assert the execution of Rename Keys node against a static test data.