### PR TITLE
Add test workflow for Mandrill node

### DIFF
--- a/workflows/132.json
+++ b/workflows/132.json
@@ -1,0 +1,77 @@
+{
+  "id": 132,
+  "name": "Mandrill:Message:sendTemplate sendHTML",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "template": "testtemplate",
+        "fromEmail": "=random{{Date.now()}}@email.test",
+        "toEmail": "=nodeqa{{Date.now()}}@email.test",
+        "options": {}
+      },
+      "name": "Mandrill",
+      "type": "n8n-nodes-base.mandrill",
+      "typeVersion": 1,
+      "position": [
+        500,
+        250
+      ],
+      "credentials": {
+        "mandrillApi": "Mandrill API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "sendHtml",
+        "fromEmail": "=random{{Date.now()}}@email.test",
+        "toEmail": "=nodeqa{{Date.now()}}@email.test",
+        "options": {
+          "html": "=<h2>This is a the html email from n8n workflow</h2>"
+        }
+      },
+      "name": "Mandrill1",
+      "type": "n8n-nodes-base.mandrill",
+      "typeVersion": 1,
+      "position": [
+        500,
+        400
+      ],
+      "credentials": {
+        "mandrillApi": "Mandrill API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Mandrill",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Mandrill1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-12T15:55:16.919Z",
+  "updatedAt": "2021-03-12T15:55:16.919Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Mandrill node

Workflow n°132 support:

- Message: sendTemplate sendHTML