### PR TITLE
Add test workflow for Twilio node

### DIFF
--- a/workflows/133.json
+++ b/workflows/133.json
@@ -1,0 +1,51 @@
+{
+  "id": 133,
+  "name": "Twilio:SMS:send",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "from": "+15005550006",
+        "to": "+15005550006",
+        "message": "=Message{{Date.now()}}"
+      },
+      "name": "Twilio",
+      "type": "n8n-nodes-base.twilio",
+      "typeVersion": 1,
+      "position": [
+        550,
+        300
+      ],
+      "credentials": {
+        "twilioApi": "Twilio API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Twilio",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-15T08:20:13.922Z",
+  "updatedAt": "2021-03-15T08:20:13.922Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Twilio node

Workflow n°133 support:

- SMS: send

Note: the Twilio node uses the test credentials to avoid any usage of the trial amount