### PR TITLE
Update Clickup workflows

### DIFF
--- a/workflows/26.json
+++ b/workflows/26.json
@@ -46,7 +46,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        610,
+        740,
         200
       ],
       "credentials": {
@@ -66,7 +66,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        750,
+        1050,
         200
       ],
       "credentials": {
@@ -85,7 +85,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        890,
+        1330,
         200
       ],
       "credentials": {
@@ -104,7 +104,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1030,
+        1610,
         200
       ],
       "credentials": {
@@ -127,7 +127,8 @@
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -142,12 +143,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1050,
+        1630,
         370
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -160,12 +162,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1200,
+        1950,
         370
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -177,12 +180,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1340,
+        2230,
         370
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -194,12 +198,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1480,
+        2510,
         370
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -213,12 +218,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        600,
+        730,
         490
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -233,12 +239,13 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        760,
+        1060,
         490
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
     },
     {
       "parameters": {
@@ -250,12 +257,145 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        900,
+        1340,
         490
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
-      }
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        590,
+        200
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        890,
+        200
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1180,
+        200
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1470,
+        200
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        580,
+        380
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        890,
+        490
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1200,
+        490
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay7",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1500,
+        370
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay8",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1790,
+        370
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay9",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2090,
+        370
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay10",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2380,
+        370
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -263,7 +403,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -274,7 +414,7 @@
       "main": [
         [
           {
-            "node": "ClickUp2",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -285,7 +425,7 @@
       "main": [
         [
           {
-            "node": "ClickUp3",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -296,7 +436,7 @@
       "main": [
         [
           {
-            "node": "ClickUp4",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -306,11 +446,6 @@
     "Start": {
       "main": [
         [
-          {
-            "node": "ClickUp5",
-            "type": "main",
-            "index": 0
-          },
           {
             "node": "ClickUp",
             "type": "main",
@@ -323,7 +458,7 @@
       "main": [
         [
           {
-            "node": "ClickUp10",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -334,7 +469,7 @@
       "main": [
         [
           {
-            "node": "ClickUp7",
+            "node": "Delay8",
             "type": "main",
             "index": 0
           }
@@ -345,7 +480,7 @@
       "main": [
         [
           {
-            "node": "ClickUp8",
+            "node": "Delay9",
             "type": "main",
             "index": 0
           }
@@ -356,7 +491,7 @@
       "main": [
         [
           {
-            "node": "ClickUp9",
+            "node": "Delay10",
             "type": "main",
             "index": 0
           }
@@ -367,7 +502,7 @@
       "main": [
         [
           {
-            "node": "ClickUp11",
+            "node": "Delay5",
             "type": "main",
             "index": 0
           }
@@ -378,7 +513,7 @@
       "main": [
         [
           {
-            "node": "ClickUp12",
+            "node": "Delay6",
             "type": "main",
             "index": 0
           }
@@ -389,7 +524,128 @@
       "main": [
         [
           {
+            "node": "Delay7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
+            "node": "ClickUp11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
+      "main": [
+        [
+          {
+            "node": "ClickUp12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay7": {
+      "main": [
+        [
+          {
             "node": "ClickUp6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay8": {
+      "main": [
+        [
+          {
+            "node": "ClickUp7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay9": {
+      "main": [
+        [
+          {
+            "node": "ClickUp8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay10": {
+      "main": [
+        [
+          {
+            "node": "ClickUp9",
             "type": "main",
             "index": 0
           }
@@ -398,7 +654,7 @@
     }
   },
   "createdAt": "2021-02-17T09:14:09.452Z",
-  "updatedAt": "2021-02-24T11:42:28.785Z",
+  "updatedAt": "2021-03-15T15:47:50.021Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/27.json
+++ b/workflows/27.json
@@ -9,7 +9,7 @@
       "type": "n8n-nodes-base.start",
       "typeVersion": 1,
       "position": [
-        230,
+        160,
         420
       ]
     },
@@ -24,7 +24,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        390,
+        320,
         310
       ],
       "credentials": {
@@ -45,7 +45,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        540,
+        590,
         340
       ],
       "credentials": {
@@ -68,7 +68,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        660,
+        870,
         660
       ],
       "retryOnFail": true,
@@ -89,7 +89,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        810,
+        1110,
         660
       ],
       "alwaysOutputData": true,
@@ -109,7 +109,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        960,
+        1410,
         660
       ],
       "alwaysOutputData": true,
@@ -131,7 +131,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1100,
+        1740,
         660
       ],
       "alwaysOutputData": true,
@@ -152,7 +152,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1240,
+        2060,
         660
       ],
       "alwaysOutputData": true,
@@ -173,7 +173,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1390,
+        2390,
         660
       ],
       "alwaysOutputData": true,
@@ -193,7 +193,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1560,
+        2680,
         660
       ],
       "credentials": {
@@ -213,7 +213,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        650,
+        860,
         460
       ],
       "credentials": {
@@ -232,7 +232,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        810,
+        1110,
         460
       ],
       "credentials": {
@@ -250,7 +250,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        960,
+        1410,
         460
       ],
       "alwaysOutputData": true,
@@ -263,8 +263,8 @@
         "operation": "getAll",
         "team": "4651110",
         "space": "8716115",
-        "folder": "23517246",
-        "list": "48641783",
+        "folder": "={{$node[\"ClickUp\"].json[\"id\"]}}",
+        "list": "={{$node[\"ClickUp1\"].json[\"id\"]}}",
         "returnAll": false,
         "limit": 1,
         "filters": {}
@@ -273,7 +273,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1110,
+        1750,
         460
       ],
       "alwaysOutputData": true,
@@ -290,7 +290,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1240,
+        2060,
         460
       ],
       "alwaysOutputData": true,
@@ -307,13 +307,181 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1390,
+        2390,
         460
       ],
       "alwaysOutputData": true,
       "credentials": {
         "clickUpApi": "clickup cred"
       }
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        450,
+        310
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        720,
+        340
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        990,
+        460
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1250,
+        460
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1580,
+        460
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1900,
+        460
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2220,
+        460
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay7",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        990,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay8",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1250,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay9",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1560,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay10",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1900,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay11",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2220,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay12",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2540,
+        660
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay13",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        710,
+        660
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -321,7 +489,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -332,7 +500,7 @@
       "main": [
         [
           {
-            "node": "ClickUp9",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -343,7 +511,7 @@
       "main": [
         [
           {
-            "node": "ClickUp3",
+            "node": "Delay7",
             "type": "main",
             "index": 0
           }
@@ -354,7 +522,7 @@
       "main": [
         [
           {
-            "node": "ClickUp4",
+            "node": "Delay8",
             "type": "main",
             "index": 0
           }
@@ -365,7 +533,7 @@
       "main": [
         [
           {
-            "node": "ClickUp5",
+            "node": "Delay9",
             "type": "main",
             "index": 0
           }
@@ -376,7 +544,7 @@
       "main": [
         [
           {
-            "node": "ClickUp6",
+            "node": "Delay10",
             "type": "main",
             "index": 0
           }
@@ -387,7 +555,7 @@
       "main": [
         [
           {
-            "node": "ClickUp7",
+            "node": "Delay11",
             "type": "main",
             "index": 0
           }
@@ -409,7 +577,7 @@
       "main": [
         [
           {
-            "node": "ClickUp8",
+            "node": "Delay12",
             "type": "main",
             "index": 0
           }
@@ -420,7 +588,7 @@
       "main": [
         [
           {
-            "node": "ClickUp10",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -431,7 +599,7 @@
       "main": [
         [
           {
-            "node": "ClickUp11",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -442,7 +610,7 @@
       "main": [
         [
           {
-            "node": "ClickUp12",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -453,7 +621,7 @@
       "main": [
         [
           {
-            "node": "ClickUp13",
+            "node": "Delay5",
             "type": "main",
             "index": 0
           }
@@ -464,7 +632,7 @@
       "main": [
         [
           {
-            "node": "ClickUp14",
+            "node": "Delay6",
             "type": "main",
             "index": 0
           }
@@ -472,6 +640,160 @@
       ]
     },
     "ClickUp14": {
+      "main": [
+        [
+          {
+            "node": "Delay13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
+      "main": [
+        [
+          {
+            "node": "ClickUp14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
+            "node": "ClickUp13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay9": {
+      "main": [
+        [
+          {
+            "node": "ClickUp5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay8": {
+      "main": [
+        [
+          {
+            "node": "ClickUp4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay7": {
+      "main": [
+        [
+          {
+            "node": "ClickUp3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay10": {
+      "main": [
+        [
+          {
+            "node": "ClickUp6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay11": {
+      "main": [
+        [
+          {
+            "node": "ClickUp7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay12": {
+      "main": [
+        [
+          {
+            "node": "ClickUp8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay13": {
       "main": [
         [
           {
@@ -484,7 +806,7 @@
     }
   },
   "createdAt": "2021-02-17T09:32:18.514Z",
-  "updatedAt": "2021-02-24T11:47:33.047Z",
+  "updatedAt": "2021-03-15T15:51:13.445Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/28.json
+++ b/workflows/28.json
@@ -45,7 +45,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        580,
+        720,
         350
       ],
       "credentials": {
@@ -65,7 +65,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        710,
+        1000,
         400
       ],
       "credentials": {
@@ -82,7 +82,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        860,
+        1320,
         400
       ],
       "credentials": {
@@ -102,7 +102,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1420,
+        2620,
         400
       ],
       "credentials": {
@@ -119,7 +119,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1550,
+        2900,
         400
       ],
       "credentials": {
@@ -139,7 +139,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1700,
+        3170,
         350
       ],
       "credentials": {
@@ -158,7 +158,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1840,
+        3450,
         290
       ],
       "credentials": {
@@ -176,7 +176,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        990,
+        1620,
         500
       ],
       "credentials": {
@@ -197,7 +197,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1140,
+        1940,
         500
       ],
       "credentials": {
@@ -215,12 +215,120 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1270,
+        2280,
         500
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
       }
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        570,
+        300
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        860,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1150,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1500,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1780,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2120,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2500,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay8",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        3050,
+        350
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay9",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        3330,
+        290
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -228,7 +336,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -239,7 +347,7 @@
       "main": [
         [
           {
-            "node": "ClickUp2",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -250,7 +358,7 @@
       "main": [
         [
           {
-            "node": "ClickUp3",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -272,7 +380,7 @@
       "main": [
         [
           {
-            "node": "ClickUp8",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -294,7 +402,7 @@
       "main": [
         [
           {
-            "node": "ClickUp4",
+            "node": "Delay8",
             "type": "main",
             "index": 0
           }
@@ -305,7 +413,7 @@
       "main": [
         [
           {
-            "node": "ClickUp7",
+            "node": "Delay9",
             "type": "main",
             "index": 0
           }
@@ -316,7 +424,7 @@
       "main": [
         [
           {
-            "node": "ClickUp9",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -327,7 +435,7 @@
       "main": [
         [
           {
-            "node": "ClickUp10",
+            "node": "Delay5",
             "type": "main",
             "index": 0
           }
@@ -335,6 +443,105 @@
       ]
     },
     "ClickUp10": {
+      "main": [
+        [
+          {
+            "node": "Delay6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
+            "node": "ClickUp10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay9": {
+      "main": [
+        [
+          {
+            "node": "ClickUp7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay8": {
+      "main": [
+        [
+          {
+            "node": "ClickUp4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
       "main": [
         [
           {
@@ -347,7 +554,7 @@
     }
   },
   "createdAt": "2021-02-17T10:31:28.487Z",
-  "updatedAt": "2021-02-24T11:49:08.808Z",
+  "updatedAt": "2021-03-15T15:26:38.816Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/29.json
+++ b/workflows/29.json
@@ -45,7 +45,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        550,
+        680,
         350
       ],
       "credentials": {
@@ -64,7 +64,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        700,
+        960,
         420
       ],
       "credentials": {
@@ -84,7 +84,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        850,
+        1230,
         420
       ],
       "credentials": {
@@ -103,7 +103,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        990,
+        1520,
         420
       ],
       "credentials": {
@@ -120,7 +120,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1140,
+        1830,
         420
       ],
       "credentials": {
@@ -139,7 +139,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1420,
+        2400,
         290
       ],
       "credentials": {
@@ -159,12 +159,96 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1280,
+        2130,
         350
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
       }
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        550,
+        300
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        810,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1100,
+        420
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1370,
+        420
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1670,
+        420
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2000,
+        350
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2270,
+        290
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -172,7 +256,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -194,7 +278,7 @@
       "main": [
         [
           {
-            "node": "ClickUp2",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -205,7 +289,7 @@
       "main": [
         [
           {
-            "node": "ClickUp3",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -216,7 +300,7 @@
       "main": [
         [
           {
-            "node": "ClickUp4",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -227,7 +311,7 @@
       "main": [
         [
           {
-            "node": "ClickUp5",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -238,7 +322,7 @@
       "main": [
         [
           {
-            "node": "ClickUp7",
+            "node": "Delay6",
             "type": "main",
             "index": 0
           }
@@ -249,7 +333,84 @@
       "main": [
         [
           {
+            "node": "Delay5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
             "node": "ClickUp6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
+      "main": [
+        [
+          {
+            "node": "ClickUp7",
             "type": "main",
             "index": 0
           }
@@ -258,7 +419,7 @@
     }
   },
   "createdAt": "2021-02-17T11:06:49.772Z",
-  "updatedAt": "2021-02-24T11:50:14.407Z",
+  "updatedAt": "2021-03-15T15:22:50.638Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/30.json
+++ b/workflows/30.json
@@ -45,7 +45,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        530,
+        700,
         350
       ],
       "credentials": {
@@ -65,8 +65,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        680,
-        410
+        990,
+        400
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -82,8 +82,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        970,
-        510
+        1530,
+        500
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -102,8 +102,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        830,
-        410
+        1250,
+        400
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -120,8 +120,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1130,
-        510
+        1810,
+        500
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -140,7 +140,7 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1270,
+        2080,
         350
       ],
       "alwaysOutputData": true,
@@ -160,12 +160,96 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1420,
+        2370,
         300
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
       }
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        550,
+        300
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        850,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1120,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1390,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1670,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1950,
+        350
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2240,
+        300
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -173,7 +257,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -184,7 +268,7 @@
       "main": [
         [
           {
-            "node": "ClickUp9",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -206,7 +290,7 @@
       "main": [
         [
           {
-            "node": "ClickUp11",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -217,7 +301,7 @@
       "main": [
         [
           {
-            "node": "ClickUp10",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -228,7 +312,7 @@
       "main": [
         [
           {
-            "node": "ClickUp12",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -239,7 +323,7 @@
       "main": [
         [
           {
-            "node": "ClickUp8",
+            "node": "Delay6",
             "type": "main",
             "index": 0
           }
@@ -250,7 +334,84 @@
       "main": [
         [
           {
+            "node": "Delay5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
+      "main": [
+        [
+          {
+            "node": "ClickUp8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
             "node": "ClickUp7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
             "type": "main",
             "index": 0
           }
@@ -259,7 +420,7 @@
     }
   },
   "createdAt": "2021-02-17T11:28:33.699Z",
-  "updatedAt": "2021-02-24T12:47:17.847Z",
+  "updatedAt": "2021-03-15T15:17:31.464Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/31.json
+++ b/workflows/31.json
@@ -9,8 +9,8 @@
       "type": "n8n-nodes-base.start",
       "typeVersion": 1,
       "position": [
-        260,
-        310
+        180,
+        300
       ]
     },
     {
@@ -24,8 +24,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        420,
-        310
+        340,
+        300
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -45,8 +45,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        550,
-        360
+        620,
+        350
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -65,8 +65,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        690,
-        420
+        880,
+        400
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -88,8 +88,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        830,
-        500
+        1230,
+        490
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -114,8 +114,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        980,
-        580
+        1530,
+        570
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -131,8 +131,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1130,
-        580
+        1900,
+        570
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -152,8 +152,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1280,
-        580
+        2210,
+        570
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -176,8 +176,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1420,
-        490
+        2490,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -195,8 +195,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1580,
-        490
+        2770,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -212,8 +212,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1720,
-        490
+        3060,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -231,8 +231,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        1860,
-        490
+        3330,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -249,8 +249,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        2020,
-        490
+        3600,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -267,8 +267,8 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        2170,
-        490
+        3870,
+        480
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
@@ -286,12 +286,168 @@
       "type": "n8n-nodes-base.clickUp",
       "typeVersion": 1,
       "position": [
-        2290,
-        340
+        4170,
+        330
       ],
       "credentials": {
         "clickUpApi": "clickup cred"
       }
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        470,
+        300
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay1",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        750,
+        350
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay2",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1020,
+        400
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay3",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1370,
+        500
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay4",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        1710,
+        570
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay5",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2050,
+        570
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay6",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2360,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay7",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2630,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay8",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        2910,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay9",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        3200,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay10",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        3470,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay11",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        3730,
+        480
+      ],
+      "typeVersion": 1
+    },
+    {
+      "parameters": {
+        "functionCode": "function sleep(milliseconds) {\n  return new Promise(\n    resolve => setTimeout(resolve, milliseconds)\n  );\n}\n\nawait sleep(500);\n\n// Output data\nreturn items;"
+      },
+      "name": "Delay12",
+      "type": "n8n-nodes-base.function",
+      "position": [
+        4050,
+        330
+      ],
+      "typeVersion": 1
     }
   ],
   "connections": {
@@ -299,7 +455,7 @@
       "main": [
         [
           {
-            "node": "ClickUp1",
+            "node": "Delay",
             "type": "main",
             "index": 0
           }
@@ -310,7 +466,7 @@
       "main": [
         [
           {
-            "node": "ClickUp9",
+            "node": "Delay1",
             "type": "main",
             "index": 0
           }
@@ -332,7 +488,7 @@
       "main": [
         [
           {
-            "node": "ClickUp10",
+            "node": "Delay2",
             "type": "main",
             "index": 0
           }
@@ -343,7 +499,7 @@
       "main": [
         [
           {
-            "node": "ClickUp11",
+            "node": "Delay3",
             "type": "main",
             "index": 0
           }
@@ -354,7 +510,7 @@
       "main": [
         [
           {
-            "node": "ClickUp12",
+            "node": "Delay4",
             "type": "main",
             "index": 0
           }
@@ -365,7 +521,7 @@
       "main": [
         [
           {
-            "node": "ClickUp13",
+            "node": "Delay5",
             "type": "main",
             "index": 0
           }
@@ -376,7 +532,7 @@
       "main": [
         [
           {
-            "node": "ClickUp14",
+            "node": "Delay6",
             "type": "main",
             "index": 0
           }
@@ -387,7 +543,7 @@
       "main": [
         [
           {
-            "node": "ClickUp15",
+            "node": "Delay7",
             "type": "main",
             "index": 0
           }
@@ -398,7 +554,7 @@
       "main": [
         [
           {
-            "node": "ClickUp16",
+            "node": "Delay8",
             "type": "main",
             "index": 0
           }
@@ -409,7 +565,7 @@
       "main": [
         [
           {
-            "node": "ClickUp17",
+            "node": "Delay9",
             "type": "main",
             "index": 0
           }
@@ -420,7 +576,7 @@
       "main": [
         [
           {
-            "node": "ClickUp18",
+            "node": "Delay10",
             "type": "main",
             "index": 0
           }
@@ -431,7 +587,7 @@
       "main": [
         [
           {
-            "node": "ClickUp19",
+            "node": "Delay11",
             "type": "main",
             "index": 0
           }
@@ -439,6 +595,149 @@
       ]
     },
     "ClickUp19": {
+      "main": [
+        [
+          {
+            "node": "Delay12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay": {
+      "main": [
+        [
+          {
+            "node": "ClickUp1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay1": {
+      "main": [
+        [
+          {
+            "node": "ClickUp9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay2": {
+      "main": [
+        [
+          {
+            "node": "ClickUp10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay3": {
+      "main": [
+        [
+          {
+            "node": "ClickUp11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay4": {
+      "main": [
+        [
+          {
+            "node": "ClickUp12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay5": {
+      "main": [
+        [
+          {
+            "node": "ClickUp13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay6": {
+      "main": [
+        [
+          {
+            "node": "ClickUp14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay7": {
+      "main": [
+        [
+          {
+            "node": "ClickUp15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay8": {
+      "main": [
+        [
+          {
+            "node": "ClickUp16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay9": {
+      "main": [
+        [
+          {
+            "node": "ClickUp17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay10": {
+      "main": [
+        [
+          {
+            "node": "ClickUp18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay11": {
+      "main": [
+        [
+          {
+            "node": "ClickUp19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delay12": {
       "main": [
         [
           {
@@ -451,7 +750,7 @@
     }
   },
   "createdAt": "2021-02-17T11:37:42.892Z",
-  "updatedAt": "2021-02-24T12:47:59.926Z",
+  "updatedAt": "2021-03-15T15:21:27.381Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr removes update the workflows n°26, 27, 28, 29, 30 and 31 to include a delay before each node.

Note: the workflow n°26 doesn't support the `Goal` resource, as we reached the trial limit (for the goal resource)