### PR TITLE
The hive/test workflows

### DIFF
--- a/workflows/137.json
+++ b/workflows/137.json
@@ -1,6 +1,6 @@
 {
   "id": 137,
-  "name": "Thehive(v3)",
+  "name": "TheHive[v3]:Alert:create update get getAll promote merge:Case:create update get getAll:Observable:create update get search getAll:Task:create update get search getAll:Log:create get getAll",
   "active": false,
   "nodes": [
     {
@@ -108,19 +108,19 @@
     {
       "parameters": {
         "operation": "merge",
-        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+        "id": "={{$node[\"TheHive30\"].json[\"id\"]}}",
+        "caseId": "={{$node[\"TheHive29\"].json[\"id\"]}}"
       },
       "name": "TheHive5",
       "type": "n8n-nodes-base.theHive",
       "typeVersion": 1,
       "position": [
-        1200,
-        300
+        750,
+        150
       ],
       "credentials": {
         "theHiveApi": "The Hive API creds"
-      },
-      "disabled": true
+      }
     },
     {
       "parameters": {
@@ -547,6 +547,50 @@
         "theHiveApi": "The Hive API creds"
       },
       "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "create",
+        "title": "=MergingCase{{Date.now()}}",
+        "description": "desc",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "owner": "nodeqa",
+        "tags": "test",
+        "options": {}
+      },
+      "name": "TheHive29",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        450,
+        150
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "title": "=MergingAlert{{Date.now()}}",
+        "description": "desc",
+        "date": "={{(new Date()).toISOString()}}",
+        "tags": "test",
+        "type": "test",
+        "source": "n8n",
+        "sourceRef": "={{Date.now().toString()}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive30",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        600,
+        150
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
     }
   ],
   "connections": {
@@ -753,6 +797,11 @@
             "node": "TheHive",
             "type": "main",
             "index": 0
+          },
+          {
+            "node": "TheHive29",
+            "type": "main",
+            "index": 0
           }
         ]
       ]
@@ -789,10 +838,32 @@
           }
         ]
       ]
+    },
+    "TheHive30": {
+      "main": [
+        [
+          {
+            "node": "TheHive5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive29": {
+      "main": [
+        [
+          {
+            "node": "TheHive30",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "createdAt": "2021-03-16T15:47:37.279Z",
-  "updatedAt": "2021-03-16T16:57:43.889Z",
+  "updatedAt": "2021-03-16T17:24:18.533Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/137.json
+++ b/workflows/137.json
@@ -1,0 +1,798 @@
+{
+  "id": 137,
+  "name": "Thehive(v3)",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "title": "=Title{{Date.now()}}",
+        "description": "desc",
+        "date": "={{(new Date()).toISOString()}}",
+        "tags": "test",
+        "type": "test",
+        "source": "n8n",
+        "sourceRef": "={{Date.now().toString()}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}",
+        "updateFields": {
+          "tlp": 1
+        }
+      },
+      "name": "TheHive1",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        600,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive2",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        750,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive3",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        900,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "promote",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive4",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "merge",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive5",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "create",
+        "title": "=Title{{Date.now()}}",
+        "description": "desc",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "owner": "nodeqa",
+        "tags": "test",
+        "options": {}
+      },
+      "name": "TheHive6",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        450,
+        600
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "update",
+        "id": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "updateFields": {
+          "tlp": 3
+        }
+      },
+      "name": "TheHive7",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        600,
+        600
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "get",
+        "id": "={{$node[\"TheHive6\"].json[\"caseId\"]}}"
+      },
+      "name": "TheHive8",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        750,
+        600
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive9",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        900,
+        600
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "executeResponder",
+        "id": "={{$node[\"TheHive6\"].json[\"caseId\"]}}"
+      },
+      "name": "TheHive10",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        600
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "create",
+        "caseId": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "title": "=Task{{Date.now()}}",
+        "options": {}
+      },
+      "name": "TheHive11",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        600,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "update",
+        "id": "={{$node[\"TheHive11\"].json[\"id\"]}}",
+        "updateFields": {
+          "status": "InProgress"
+        }
+      },
+      "name": "TheHive12",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        750,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "get",
+        "id": "={{$node[\"TheHive11\"].json[\"id\"]}}"
+      },
+      "name": "TheHive13",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        900,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "search",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive14",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "create",
+        "taskId": "={{$node[\"TheHive11\"].json[\"id\"]}}",
+        "message": "=Message{{Date.now()}}",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "status": "Ok",
+        "options": {}
+      },
+      "name": "TheHive16",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        750,
+        930
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "get",
+        "id": "={{$node[\"TheHive16\"].json[\"_id\"]}}"
+      },
+      "name": "TheHive17",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        900,
+        930
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "taskId": "={{$node[\"TheHive16\"].json[\"_id\"]}}",
+        "limit": 1
+      },
+      "name": "TheHive18",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        930
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "create",
+        "caseId": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "dataType": "ip",
+        "data": "36.123.133.214",
+        "message": "test",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "ioc": true,
+        "status": "Ok",
+        "options": {}
+      },
+      "name": "TheHive19",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        600,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "update",
+        "id": "={{$node[\"TheHive19\"].json[\"_id\"]}}",
+        "updateFields": {
+          "ioc": false
+        }
+      },
+      "name": "TheHive20",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        750,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "get",
+        "id": "={{$node[\"TheHive19\"].json[\"_id\"]}}"
+      },
+      "name": "TheHive21",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        900,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "search",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive22",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "caseId": "={{$node[\"TheHive6\"].json[\"_id\"]}}",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "TheHive23",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeResponder",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive15",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1340,
+        300
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "executeAnalyzer"
+      },
+      "name": "TheHive24",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive25",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1500,
+        450
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "caseId": "={{$node[\"TheHive6\"].json[\"_id\"]}}",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "TheHive26",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive27",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        770
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive28",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        930
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds"
+      },
+      "disabled": true
+    }
+  ],
+  "connections": {
+    "TheHive": {
+      "main": [
+        [
+          {
+            "node": "TheHive1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive1": {
+      "main": [
+        [
+          {
+            "node": "TheHive2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive2": {
+      "main": [
+        [
+          {
+            "node": "TheHive3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive3": {
+      "main": [
+        [
+          {
+            "node": "TheHive4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive6": {
+      "main": [
+        [
+          {
+            "node": "TheHive7",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive11",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive7": {
+      "main": [
+        [
+          {
+            "node": "TheHive8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive8": {
+      "main": [
+        [
+          {
+            "node": "TheHive9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive11": {
+      "main": [
+        [
+          {
+            "node": "TheHive12",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive12": {
+      "main": [
+        [
+          {
+            "node": "TheHive13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive13": {
+      "main": [
+        [
+          {
+            "node": "TheHive14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive16": {
+      "main": [
+        [
+          {
+            "node": "TheHive17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive17": {
+      "main": [
+        [
+          {
+            "node": "TheHive18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive19": {
+      "main": [
+        [
+          {
+            "node": "TheHive20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive20": {
+      "main": [
+        [
+          {
+            "node": "TheHive21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive21": {
+      "main": [
+        [
+          {
+            "node": "TheHive22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive22": {
+      "main": [
+        [
+          {
+            "node": "TheHive23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "TheHive6",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive14": {
+      "main": [
+        [
+          {
+            "node": "TheHive26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive26": {
+      "main": [
+        [
+          {
+            "node": "TheHive27",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive18": {
+      "main": [
+        [
+          {
+            "node": "TheHive28",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-16T15:47:37.279Z",
+  "updatedAt": "2021-03-16T16:57:43.889Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/138.json
+++ b/workflows/138.json
@@ -1,0 +1,892 @@
+{
+  "id": 138,
+  "name": "Thehive(v4)",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "title": "=Title{{Date.now()}}",
+        "description": "desc",
+        "date": "={{(new Date()).toISOString()}}",
+        "tags": "test",
+        "type": "test",
+        "source": "n8n",
+        "sourceRef": "={{Date.now().toString()}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        470,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}",
+        "updateFields": {
+          "tlp": 1
+        }
+      },
+      "name": "TheHive1",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        620,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive2",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive3",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        920,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "promote",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive4",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "merge",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive5",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1450,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "create",
+        "title": "=Title{{Date.now()}}",
+        "description": "desc",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "owner": "nodeqa",
+        "tags": "test",
+        "options": {}
+      },
+      "name": "TheHive6",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        470,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "update",
+        "id": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "updateFields": {
+          "tlp": 3
+        }
+      },
+      "name": "TheHive7",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        620,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "get",
+        "id": "={{$node[\"TheHive6\"].json[\"id\"]}}"
+      },
+      "name": "TheHive8",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive9",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        920,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "executeResponder",
+        "id": "={{$node[\"TheHive6\"].json[\"caseId\"]}}"
+      },
+      "name": "TheHive10",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "create",
+        "caseId": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "title": "=Task{{Date.now()}}",
+        "options": {}
+      },
+      "name": "TheHive11",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        620,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "update",
+        "id": "={{$node[\"TheHive11\"].json[\"id\"]}}",
+        "updateFields": {
+          "status": "InProgress"
+        }
+      },
+      "name": "TheHive12",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "get",
+        "id": "={{$node[\"TheHive11\"].json[\"id\"]}}"
+      },
+      "name": "TheHive13",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        920,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "search",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive14",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "create",
+        "taskId": "={{$node[\"TheHive11\"].json[\"id\"]}}",
+        "message": "=Message{{Date.now()}}",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "status": "Ok",
+        "options": {}
+      },
+      "name": "TheHive16",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        680
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "get",
+        "id": "={{$node[\"TheHive16\"].json[\"_id\"]}}"
+      },
+      "name": "TheHive17",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        920,
+        680
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "taskId": "={{$node[\"TheHive16\"].json[\"_id\"]}}",
+        "limit": 1
+      },
+      "name": "TheHive18",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        680
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "create",
+        "caseId": "={{$node[\"TheHive6\"].json[\"caseId\"]}}",
+        "dataType": "ip",
+        "data": "36.123.133.214",
+        "message": "test",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "ioc": true,
+        "status": "Ok",
+        "options": {}
+      },
+      "name": "TheHive19",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        620,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "update",
+        "id": "={{$node[\"TheHive19\"].json[\"_id\"]}}",
+        "updateFields": {
+          "ioc": false
+        }
+      },
+      "name": "TheHive20",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "get",
+        "id": "={{$node[\"TheHive19\"].json[\"_id\"]}}"
+      },
+      "name": "TheHive21",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        920,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "search",
+        "limit": 1,
+        "options": {},
+        "filters": {}
+      },
+      "name": "TheHive22",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "caseId": "={{$node[\"TheHive6\"].json[\"_id\"]}}",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "TheHive23",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1220,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeResponder",
+        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
+      },
+      "name": "TheHive15",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1590,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "executeAnalyzer"
+      },
+      "name": "TheHive24",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1510,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive25",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1660,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "caseId": "={{$node[\"TheHive6\"].json[\"_id\"]}}",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "TheHive26",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1220,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive27",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1510,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "log",
+        "operation": "executeResponder"
+      },
+      "name": "TheHive28",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1220,
+        680
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "operation": "count",
+        "filters": {}
+      },
+      "name": "TheHive29",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1240,
+        50
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "observable",
+        "operation": "count",
+        "filters": {}
+      },
+      "name": "TheHive30",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        200
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "count",
+        "filters": {}
+      },
+      "name": "TheHive31",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        350
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "count",
+        "filters": {}
+      },
+      "name": "TheHive32",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    }
+  ],
+  "connections": {
+    "TheHive": {
+      "main": [
+        [
+          {
+            "node": "TheHive1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive1": {
+      "main": [
+        [
+          {
+            "node": "TheHive2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive2": {
+      "main": [
+        [
+          {
+            "node": "TheHive3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive3": {
+      "main": [
+        [
+          {
+            "node": "TheHive4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive6": {
+      "main": [
+        [
+          {
+            "node": "TheHive7",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive11",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive7": {
+      "main": [
+        [
+          {
+            "node": "TheHive8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive8": {
+      "main": [
+        [
+          {
+            "node": "TheHive9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive11": {
+      "main": [
+        [
+          {
+            "node": "TheHive12",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive12": {
+      "main": [
+        [
+          {
+            "node": "TheHive13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive13": {
+      "main": [
+        [
+          {
+            "node": "TheHive14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive14": {
+      "main": [
+        [
+          {
+            "node": "TheHive26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive16": {
+      "main": [
+        [
+          {
+            "node": "TheHive17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive17": {
+      "main": [
+        [
+          {
+            "node": "TheHive18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive18": {
+      "main": [
+        []
+      ]
+    },
+    "TheHive19": {
+      "main": [
+        [
+          {
+            "node": "TheHive20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive20": {
+      "main": [
+        [
+          {
+            "node": "TheHive21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive21": {
+      "main": [
+        [
+          {
+            "node": "TheHive22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive22": {
+      "main": [
+        [
+          {
+            "node": "TheHive23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive26": {
+      "main": [
+        [
+          {
+            "node": "TheHive32",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "TheHive6",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "TheHive",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive4": {
+      "main": [
+        [
+          {
+            "node": "TheHive29",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive23": {
+      "main": [
+        [
+          {
+            "node": "TheHive30",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive9": {
+      "main": [
+        [
+          {
+            "node": "TheHive31",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-16T16:58:12.352Z",
+  "updatedAt": "2021-03-16T17:10:30.692Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/138.json
+++ b/workflows/138.json
@@ -1,6 +1,6 @@
 {
   "id": 138,
-  "name": "Thehive(v4)",
+  "name": "TheHive[v4]:Alert:create update get getAll promote merge:Case:create update get getAll:Observable:create update get search getAll:Task:create update get search getAll:Log:create get getAll",
   "active": false,
   "nodes": [
     {
@@ -104,23 +104,6 @@
       "credentials": {
         "theHiveApi": "The Hive API creds (v1)"
       }
-    },
-    {
-      "parameters": {
-        "operation": "merge",
-        "id": "={{$node[\"TheHive\"].json[\"id\"]}}"
-      },
-      "name": "TheHive5",
-      "type": "n8n-nodes-base.theHive",
-      "typeVersion": 1,
-      "position": [
-        1450,
-        50
-      ],
-      "credentials": {
-        "theHiveApi": "The Hive API creds (v1)"
-      },
-      "disabled": true
     },
     {
       "parameters": {
@@ -454,7 +437,7 @@
       "type": "n8n-nodes-base.theHive",
       "typeVersion": 1,
       "position": [
-        1590,
+        1400,
         50
       ],
       "credentials": {
@@ -610,6 +593,67 @@
       "position": [
         1350,
         520
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "merge",
+        "id": "={{$node[\"TheHive35\"].json[\"id\"]}}",
+        "caseId": "={{$node[\"TheHive34\"].json[\"id\"]}}"
+      },
+      "name": "TheHive33",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        770,
+        -100
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "create",
+        "title": "=MergingCase{{Date.now()}}",
+        "description": "desc",
+        "startDate": "={{(new Date()).toISOString()}}",
+        "owner": "nodeqa",
+        "tags": "test",
+        "options": {}
+      },
+      "name": "TheHive34",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        470,
+        -100
+      ],
+      "credentials": {
+        "theHiveApi": "The Hive API creds (v1)"
+      }
+    },
+    {
+      "parameters": {
+        "title": "=MergingAlert{{Date.now()}}",
+        "description": "desc",
+        "date": "={{(new Date()).toISOString()}}",
+        "tags": "test",
+        "type": "test",
+        "source": "n8n",
+        "sourceRef": "={{Date.now().toString()}}",
+        "additionalFields": {}
+      },
+      "name": "TheHive35",
+      "type": "n8n-nodes-base.theHive",
+      "typeVersion": 1,
+      "position": [
+        620,
+        -100
       ],
       "credentials": {
         "theHiveApi": "The Hive API creds (v1)"
@@ -775,11 +819,6 @@
         ]
       ]
     },
-    "TheHive18": {
-      "main": [
-        []
-      ]
-    },
     "TheHive19": {
       "main": [
         [
@@ -847,6 +886,11 @@
             "node": "TheHive",
             "type": "main",
             "index": 0
+          },
+          {
+            "node": "TheHive34",
+            "type": "main",
+            "index": 0
           }
         ]
       ]
@@ -883,10 +927,32 @@
           }
         ]
       ]
+    },
+    "TheHive34": {
+      "main": [
+        [
+          {
+            "node": "TheHive35",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "TheHive35": {
+      "main": [
+        [
+          {
+            "node": "TheHive33",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "createdAt": "2021-03-16T16:58:12.352Z",
-  "updatedAt": "2021-03-16T17:10:30.692Z",
+  "updatedAt": "2021-03-16T17:24:47.184Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr includes 2 workflows to test the TheHive nodes, each workflow uses a different API version

Workflow n°137 uses API v0 support:

- Alert: create update get getAll promote merge
- Case: create update get getAll
- Observable: create update get search getAll
- Task: create update get search getAll
- Log: create get getAll

Workflow n°138 uses API v1 support the same as workflow 137 with extra operation `Count` for `Alert`, `Case` `Observable` and `Task` resources

Note: the two workflow doesn't support the `exectueResponder` and `executeAnalyzer` operations.