### PR TITLE
Add test workflow for Mailgun node

### DIFF
--- a/workflows/140.json
+++ b/workflows/140.json
@@ -1,0 +1,52 @@
+{
+  "id": 140,
+  "name": "Mailgun",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "fromEmail": "nodeqa@n8n.io",
+        "toEmail": "node8qa@gmail.com",
+        "subject": "=Mailgun{{Date.now()}}",
+        "text": "=Test text {{(new Date).toUTCString()}}"
+      },
+      "name": "Mailgun",
+      "type": "n8n-nodes-base.mailgun",
+      "typeVersion": 1,
+      "position": [
+        470,
+        300
+      ],
+      "credentials": {
+        "mailgunApi": "Mailgun API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Mailgun",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-19T09:48:14.284Z",
+  "updatedAt": "2021-03-19T09:48:14.284Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Mailgun node

Workflow n°140 support sending an email from Mailgun sandbox email domain to a validated recipient account. 