### PR TITLE
Add test workflow for Clearbit node

### DIFF
--- a/workflows/143.json
+++ b/workflows/143.json
@@ -1,0 +1,105 @@
+{
+  "id": 143,
+  "name": "Clearbit:Company:enrich:Person:enrich",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        -60,
+        280
+      ]
+    },
+    {
+      "parameters": {
+        "domain": "n8n.io",
+        "additionalFields": {
+          "companyName": "n8n",
+          "twitter": "n8n_io"
+        }
+      },
+      "name": "Clearbit",
+      "type": "n8n-nodes-base.clearbit",
+      "typeVersion": 1,
+      "position": [
+        150,
+        200
+      ],
+      "credentials": {
+        "clearbitApi": "Clearbit API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "autocomplete",
+        "name": "n8n"
+      },
+      "name": "Clearbit1",
+      "type": "n8n-nodes-base.clearbit",
+      "typeVersion": 1,
+      "position": [
+        350,
+        200
+      ],
+      "credentials": {
+        "clearbitApi": "Clearbit API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "email": "jan@n8n.io",
+        "additionalFields": {
+          "company": "n8n"
+        }
+      },
+      "name": "Clearbit2",
+      "type": "n8n-nodes-base.clearbit",
+      "typeVersion": 1,
+      "position": [
+        150,
+        350
+      ],
+      "credentials": {
+        "clearbitApi": "Clearbit API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Clearbit": {
+      "main": [
+        [
+          {
+            "node": "Clearbit1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Clearbit2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Clearbit",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-22T11:26:13.716Z",
+  "updatedAt": "2021-03-22T11:36:27.741Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/143.json
+++ b/workflows/143.json
@@ -1,6 +1,6 @@
 {
   "id": 143,
-  "name": "Clearbit:Company:enrich:Person:enrich",
+  "name": "Clearbit:Company:enrich autocomplete:Person:enrich",
   "active": false,
   "nodes": [
     {
@@ -46,8 +46,7 @@
       ],
       "credentials": {
         "clearbitApi": "Clearbit API creds"
-      },
-      "disabled": true
+      }
     },
     {
       "parameters": {
@@ -99,7 +98,7 @@
     }
   },
   "createdAt": "2021-03-22T11:26:13.716Z",
-  "updatedAt": "2021-03-22T11:36:27.741Z",
+  "updatedAt": "2021-03-24T08:32:29.467Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr includes a workflow to test the Clearbit node

Workflow n°143 support:

- Company: enrich autocomplete
- Person: enrich

~~Note: the workflow doesn't support the `autocomplete` operation, opened a [pr](https://github.com/n8n-io/n8n/pull/1564) to fix it~~ 