### PR TITLE
Add test workflow for PostHog node

### DIFF
--- a/workflows/150.json
+++ b/workflows/150.json
@@ -1,0 +1,189 @@
+{
+  "id": 150,
+  "name": "PostHog:Event:create:Identity:create:Alias:create:Track:page screen",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "eventName": "=Event{{Date.now()}}",
+        "distinctId": "={{Date.now()}}",
+        "additionalFields": {
+          "propertiesUi": {
+            "propertyValues": [
+              {
+                "key": "name",
+                "value": "test"
+              }
+            ]
+          },
+          "timestamp": "={{(new Date()).toISOString()}}"
+        }
+      },
+      "name": "PostHog",
+      "type": "n8n-nodes-base.postHog",
+      "typeVersion": 1,
+      "position": [
+        500,
+        150
+      ],
+      "credentials": {
+        "postHogApi": "PostHog API"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "identity",
+        "distinctId": "={{Date.now()}}",
+        "additionalFields": {
+          "propertiesUi": {
+            "propertyValues": [
+              {
+                "key": "name",
+                "value": "identity test"
+              },
+              {
+                "key": "email",
+                "value": "=fake{{Date.now()}}@gmail.com"
+              }
+            ]
+          },
+          "timestamp": "={{Date.now()}}"
+        }
+      },
+      "name": "PostHog1",
+      "type": "n8n-nodes-base.postHog",
+      "typeVersion": 1,
+      "position": [
+        500,
+        300
+      ],
+      "credentials": {
+        "postHogApi": "PostHog API"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "alias",
+        "alias": "=Alias{{Date.now()}}",
+        "distinctId": "={{Date.now()}}",
+        "additionalFields": {
+          "contextUi": {
+            "contextValues": [
+              {
+                "key": "name",
+                "value": "Aliastest"
+              }
+            ]
+          },
+          "timestamp": "={{Date.now()}}"
+        }
+      },
+      "name": "PostHog2",
+      "type": "n8n-nodes-base.postHog",
+      "typeVersion": 1,
+      "position": [
+        500,
+        450
+      ],
+      "credentials": {
+        "postHogApi": "PostHog API"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "track",
+        "name": "=TrackPage{{Date.now()}}",
+        "distinctId": "={{Date.now()}}",
+        "additionalFields": {
+          "category": "landing",
+          "timestamp": "={{Date.now()}}"
+        }
+      },
+      "name": "PostHog3",
+      "type": "n8n-nodes-base.postHog",
+      "typeVersion": 1,
+      "position": [
+        500,
+        600
+      ],
+      "credentials": {
+        "postHogApi": "PostHog API"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "track",
+        "operation": "screen",
+        "name": "=TrackScreen{{Date.now()}}",
+        "distinctId": "={{Date.now()}}",
+        "additionalFields": {
+          "category": "registration",
+          "timestamp": "={{Date.now()}}"
+        }
+      },
+      "name": "PostHog4",
+      "type": "n8n-nodes-base.postHog",
+      "typeVersion": 1,
+      "position": [
+        650,
+        600
+      ],
+      "credentials": {
+        "postHogApi": "PostHog API"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "PostHog",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "PostHog1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "PostHog2",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "PostHog3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "PostHog3": {
+      "main": [
+        [
+          {
+            "node": "PostHog4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-24T13:20:07.626Z",
+  "updatedAt": "2021-03-24T13:33:51.181Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the PostHog node

Workflow n°150 support:

- Event: create
- Identity: create
- Alias: create
- Track: page screen