### PR TITLE
Add test workflow for Vonage node

### DIFF
--- a/workflows/161.json
+++ b/workflows/161.json
@@ -1,0 +1,52 @@
+{
+  "id": 161,
+  "name": "Vonage:SMS:send",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "from": "21624827732",
+        "to": "21624827732",
+        "message": "=Message{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Vonage",
+      "type": "n8n-nodes-base.vonage",
+      "typeVersion": 1,
+      "position": [
+        450,
+        300
+      ],
+      "credentials": {
+        "vonageApi": "Vonage API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Vonage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-03-29T08:38:31.241Z",
+  "updatedAt": "2021-03-29T08:39:51.181Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Vonage node

Workflow n°161 support:

- SMS:send

Note: based on the current account balance (11,81), we are limited to 130 API calls, until we increase the balance again (on 1st April)