### PR TITLE
Update Github test workflow to include extended release operations

### DIFF
--- a/workflows/39.json
+++ b/workflows/39.json
@@ -112,6 +112,7 @@
         "resource": "repository",
         "owner": "nodemationqa",
         "repository": "nodeQA",
+        "limit": 1,
         "getRepositoryIssuesFilters": {}
       },
       "name": "GitHub5",
@@ -124,8 +125,7 @@
       "alwaysOutputData": true,
       "credentials": {
         "githubApi": "Github creds"
-      },
-      "disabled": true
+      }
     },
     {
       "parameters": {
@@ -523,8 +523,8 @@
         "repository": "nodeQA",
         "release_id": "={{$node[\"GitHub15\"].json[\"id\"]}}",
         "additionalFields": {
-          "name": "=Updated{{$node[\"GitHub15\"].json[\"name\"]}}",
           "draft": true,
+          "name": "=Updated{{$node[\"GitHub15\"].json[\"name\"]}}",
           "tag_name": "=Updated{{$node[\"GitHub15\"].json[\"tag_name\"]}}"
         }
       },
@@ -820,7 +820,7 @@
     }
   },
   "createdAt": "2021-02-18T10:30:52.070Z",
-  "updatedAt": "2021-04-01T10:33:08.614Z",
+  "updatedAt": "2021-04-23T11:28:54.118Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/39.json
+++ b/workflows/39.json
@@ -1,6 +1,6 @@
 {
   "id": 39,
-  "name": "Github:Repository:get getProfile getLicense listPopularPaths listReferrers:File:create edit get delete:Issue:create createComment edit get lock:Release: create:User:getRepositories invite:Review:create getAll get update",
+  "name": "Github:Repository:get getProfile getLicense listPopularPaths listReferrers:File:create edit get delete:Issue:create createComment edit get lock:Release:create get getAll update delete:User:getRepositories invite:Review:create getAll get update",
   "active": false,
   "nodes": [
     {
@@ -820,7 +820,7 @@
     }
   },
   "createdAt": "2021-02-18T10:30:52.070Z",
-  "updatedAt": "2021-04-01T10:26:55.423Z",
+  "updatedAt": "2021-04-01T10:33:08.614Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/39.json
+++ b/workflows/39.json
@@ -335,9 +335,9 @@
         "resource": "release",
         "owner": "nodemationqa",
         "repository": "nodeQA",
-        "releaseTag": "release_test_tag",
+        "releaseTag": "=Release{{Date.now()}}",
         "additionalFields": {
-          "name": "=Release tag {{(new Date()).toGMTString()}}",
+          "name": "=Release {{(new Date()).toGMTString()}}",
           "draft": true
         }
       },
@@ -469,6 +469,91 @@
       "position": [
         900,
         1080
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "release",
+        "operation": "getAll",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "limit": 1
+      },
+      "name": "GitHub22",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        620,
+        770
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "release",
+        "operation": "get",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "release_id": "={{$node[\"GitHub15\"].json[\"id\"]}}"
+      },
+      "name": "GitHub23",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        770,
+        770
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "release",
+        "operation": "update",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "release_id": "={{$node[\"GitHub15\"].json[\"id\"]}}",
+        "additionalFields": {
+          "name": "=Updated{{$node[\"GitHub15\"].json[\"name\"]}}",
+          "draft": true,
+          "tag_name": "=Updated{{$node[\"GitHub15\"].json[\"tag_name\"]}}"
+        }
+      },
+      "name": "GitHub24",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        920,
+        770
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "githubApi": "Github creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "release",
+        "operation": "delete",
+        "owner": "nodemationqa",
+        "repository": "nodeQA",
+        "release_id": "={{$node[\"GitHub15\"].json[\"id\"]}}"
+      },
+      "name": "GitHub25",
+      "type": "n8n-nodes-base.github",
+      "typeVersion": 1,
+      "position": [
+        1060,
+        770
       ],
       "alwaysOutputData": true,
       "credentials": {
@@ -688,10 +773,54 @@
           }
         ]
       ]
+    },
+    "GitHub15": {
+      "main": [
+        [
+          {
+            "node": "GitHub22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub22": {
+      "main": [
+        [
+          {
+            "node": "GitHub23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub23": {
+      "main": [
+        [
+          {
+            "node": "GitHub24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GitHub24": {
+      "main": [
+        [
+          {
+            "node": "GitHub25",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "createdAt": "2021-02-18T10:30:52.070Z",
-  "updatedAt": "2021-03-01T13:23:04.461Z",
+  "updatedAt": "2021-04-01T10:26:55.423Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
this PR update Github workflow to support:

- Release: get getAll update delete

Note: this workflow will rely on the changes included in Github node through this [PR](https://github.com/n8n-io/n8n/pull/1617) 