### PR TITLE
Add delete:Folder operation to Microsoft OneDrive test workflow

### DIFF
--- a/workflows/82.json
+++ b/workflows/82.json
@@ -58,8 +58,8 @@
       "type": "n8n-nodes-base.microsoftOneDrive",
       "typeVersion": 1,
       "position": [
-        2010,
-        300
+        2000,
+        150
       ],
       "alwaysOutputData": true,
       "credentials": {
@@ -220,7 +220,7 @@
       "type": "n8n-nodes-base.microsoftOneDrive",
       "typeVersion": 1,
       "position": [
-        2150,
+        2000,
         300
       ],
       "alwaysOutputData": true,
@@ -255,6 +255,11 @@
     "Microsoft OneDrive3": {
       "main": [
         [
+          {
+            "node": "Microsoft OneDrive11",
+            "type": "main",
+            "index": 0
+          },
           {
             "node": "Microsoft OneDrive2",
             "type": "main",
@@ -353,18 +358,17 @@
     },
     "Microsoft OneDrive2": {
       "main": [
-        [
-          {
-            "node": "Microsoft OneDrive11",
-            "type": "main",
-            "index": 0
-          }
-        ]
+        []
+      ]
+    },
+    "Microsoft OneDrive11": {
+      "main": [
+        []
       ]
     }
   },
   "createdAt": "2021-03-01T10:15:48.446Z",
-  "updatedAt": "2021-04-08T11:03:55.602Z",
+  "updatedAt": "2021-04-23T13:45:19.671Z",
   "settings": {},
   "staticData": null
 }

--- a/workflows/82.json
+++ b/workflows/82.json
@@ -1,6 +1,6 @@
 {
   "id": 82,
-  "name": "Microsoft OneDrive:Folder:create getChildren share search:File:upload get share download copy delete search",
+  "name": "Microsoft OneDrive:Folder:create getChildren share search delete:File:upload get share download copy delete search",
   "active": false,
   "nodes": [
     {
@@ -52,7 +52,7 @@
       "parameters": {
         "resource": "folder",
         "operation": "search",
-        "query": "test"
+        "query": "TestFolder"
       },
       "name": "Microsoft OneDrive2",
       "type": "n8n-nodes-base.microsoftOneDrive",
@@ -209,6 +209,24 @@
       "credentials": {
         "microsoftOneDriveOAuth2Api": "Microsoft Drive OAuth2 creds"
       }
+    },
+    {
+      "parameters": {
+        "resource": "folder",
+        "operation": "delete",
+        "folderId": "={{$node[\"Microsoft OneDrive\"].json[\"id\"]}}"
+      },
+      "name": "Microsoft OneDrive11",
+      "type": "n8n-nodes-base.microsoftOneDrive",
+      "typeVersion": 1,
+      "position": [
+        2150,
+        300
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "microsoftOneDriveOAuth2Api": "Microsoft Drive OAuth2 creds"
+      }
     }
   ],
   "connections": {
@@ -332,10 +350,21 @@
           }
         ]
       ]
+    },
+    "Microsoft OneDrive2": {
+      "main": [
+        [
+          {
+            "node": "Microsoft OneDrive11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "createdAt": "2021-03-01T10:15:48.446Z",
-  "updatedAt": "2021-03-01T11:29:30.539Z",
+  "updatedAt": "2021-04-08T11:03:55.602Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr update the Microsoft OneDrive test workflow to support:

- Folder: delete

Note: this update relies on the changes within this [pr](https://github.com/n8n-io/n8n/pull/1636)