### PR TITLE
Add test workflow for Mocean node

### DIFF
--- a/workflows/169.json
+++ b/workflows/169.json
@@ -1,0 +1,76 @@
+{
+  "id": 169,
+  "name": "Mocean:SMS:send",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "from": "Nodeqa",
+        "to": "21624827732",
+        "message": "=SMS-TEST-{{Date.now()}}"
+      },
+      "name": "Mocean",
+      "type": "n8n-nodes-base.mocean",
+      "typeVersion": 1,
+      "position": [
+        500,
+        200
+      ],
+      "credentials": {
+        "moceanApi": "Mocean Api creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "voice",
+        "from": "Nodeqa",
+        "to": "21624827732",
+        "language": "en-GB",
+        "message": "=SMS{{Date.now()}}"
+      },
+      "name": "Mocean1",
+      "type": "n8n-nodes-base.mocean",
+      "typeVersion": 1,
+      "position": [
+        500,
+        350
+      ],
+      "credentials": {
+        "moceanApi": "Mocean Api creds"
+      },
+      "disabled": true
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Mocean",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Mocean1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-19T08:59:29.617Z",
+  "updatedAt": "2021-04-19T08:59:29.617Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Mocean node

Workflow n°169 support:

- SMS:send

Note: The `voice:send` operation is disabled to its high credit consumption.