### PR TITLE
Add test workflows for uProc node

### DIFF
--- a/workflows/176.json
+++ b/workflows/176.json
@@ -1,0 +1,1046 @@
+{
+  "id": 176,
+  "name": "uProc:Audio:*:company:*;",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "group": "audio",
+        "text": "n8n rocks!",
+        "gender": "female",
+        "language": "american",
+        "additionalOptions": {}
+      },
+      "name": "uProc",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        560,
+        200
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "audio",
+        "tool": "getAudioSpeechByText",
+        "text": "n8n rocks!",
+        "gender": "female",
+        "language": "american",
+        "additionalOptions": {}
+      },
+      "name": "uProc1",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        740,
+        200
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCifNormalized",
+        "cif": "B 12345 678",
+        "additionalOptions": {}
+      },
+      "name": "uProc10",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        560,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "cif": "B 12345 678",
+        "additionalOptions": {}
+      },
+      "name": "uProc11",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        690,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "checkNumberIsin",
+        "isin": "US0004026250",
+        "additionalOptions": {}
+      },
+      "name": "uProc12",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        820,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "checkNumberSsEs",
+        "number": "998239812282",
+        "additionalOptions": {}
+      },
+      "name": "uProc13",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        950,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByCif",
+        "cif": "B 12345 678",
+        "additionalOptions": {}
+      },
+      "name": "uProc14",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1080,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc15",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1210,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByDuns",
+        "duns": "150483782",
+        "additionalOptions": {}
+      },
+      "name": "uProc16",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1340,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByEmail",
+        "email": "hello@n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc17",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1470,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc18",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1600,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByName",
+        "country": "DE",
+        "name": "n8n",
+        "additionalOptions": {}
+      },
+      "name": "uProc19",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1730,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByPhone",
+        "phone": "932187670",
+        "additionalOptions": {}
+      },
+      "name": "uProc20",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1860,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyByProfile",
+        "url": "https://twitter.com/n8n_io",
+        "additionalOptions": {}
+      },
+      "name": "uProc21",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1990,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getRoleClassified",
+        "role": "Junior web developer",
+        "additionalOptions": {}
+      },
+      "name": "uProc22",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2120,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "checkCompanyDebtorByTaxid",
+        "taxid": "B12345678",
+        "additionalOptions": {}
+      },
+      "name": "uProc23",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2250,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getPersonDecisionMaker",
+        "company": "n8n.io",
+        "area": "Engineering",
+        "additionalOptions": {}
+      },
+      "name": "uProc24",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2380,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getPersonDecisionMakerBySearch",
+        "company": "n8n.io",
+        "area": "Product",
+        "clevel": "No",
+        "additionalOptions": {}
+      },
+      "name": "uProc25",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2510,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyDomainByName",
+        "name": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc26",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2640,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getPersonEmailsByDomainAndArea",
+        "domain": "n8n.io",
+        "area": "Engineering",
+        "additionalOptions": {}
+      },
+      "name": "uProc27",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2770,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyExtendedByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc28",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2900,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyExtendedByEmail",
+        "email": "hello@n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc29",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3030,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getProfileFacebookByCompany",
+        "company": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc30",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3160,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyFinancialByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc31",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3290,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyFinancialByDuns",
+        "duns": "150483782",
+        "additionalOptions": {}
+      },
+      "name": "uProc32",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3420,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyFinancialByName",
+        "name": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc33",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3550,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyFinancialByTaxid",
+        "taxid": "B12345678",
+        "additionalOptions": {}
+      },
+      "name": "uProc34",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3680,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyGeocodedByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc35",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3810,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getProfileLinkedinByCompany",
+        "company": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc36",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3940,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getPersonListByParams",
+        "country": "DE",
+        "phone": "932187670",
+        "email": "hello@n8n.io",
+        "company": "n8n.io",
+        "area": "Information technology",
+        "seniority": "Intermediate",
+        "additionalOptions": {}
+      },
+      "name": "uProc37",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4070,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getPersonMultipleDecisionMakerBySearch",
+        "company": "n8n.io",
+        "area": "Information technology",
+        "clevel": "No",
+        "additionalOptions": {}
+      },
+      "name": "uProc38",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4200,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyNameByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc39",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4330,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyPhoneByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc40",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4460,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getCompanyPhoneByName",
+        "name": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc41",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4590,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "company",
+        "tool": "getProfileTwitterByCompany",
+        "company": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc42",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        4720,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    }
+  ],
+  "connections": {
+    "uProc": {
+      "main": [
+        [
+          {
+            "node": "uProc1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc10": {
+      "main": [
+        [
+          {
+            "node": "uProc11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc11": {
+      "main": [
+        [
+          {
+            "node": "uProc12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc12": {
+      "main": [
+        [
+          {
+            "node": "uProc13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc13": {
+      "main": [
+        [
+          {
+            "node": "uProc14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc14": {
+      "main": [
+        [
+          {
+            "node": "uProc15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc15": {
+      "main": [
+        [
+          {
+            "node": "uProc16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc16": {
+      "main": [
+        [
+          {
+            "node": "uProc17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc17": {
+      "main": [
+        [
+          {
+            "node": "uProc18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc18": {
+      "main": [
+        [
+          {
+            "node": "uProc19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc19": {
+      "main": [
+        [
+          {
+            "node": "uProc20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc20": {
+      "main": [
+        [
+          {
+            "node": "uProc21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc21": {
+      "main": [
+        [
+          {
+            "node": "uProc22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc22": {
+      "main": [
+        [
+          {
+            "node": "uProc23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc23": {
+      "main": [
+        [
+          {
+            "node": "uProc24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc24": {
+      "main": [
+        [
+          {
+            "node": "uProc25",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc25": {
+      "main": [
+        [
+          {
+            "node": "uProc26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc26": {
+      "main": [
+        [
+          {
+            "node": "uProc27",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc27": {
+      "main": [
+        [
+          {
+            "node": "uProc28",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc28": {
+      "main": [
+        [
+          {
+            "node": "uProc29",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc29": {
+      "main": [
+        [
+          {
+            "node": "uProc30",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc30": {
+      "main": [
+        [
+          {
+            "node": "uProc31",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc31": {
+      "main": [
+        [
+          {
+            "node": "uProc32",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc32": {
+      "main": [
+        [
+          {
+            "node": "uProc33",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc33": {
+      "main": [
+        [
+          {
+            "node": "uProc34",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc34": {
+      "main": [
+        [
+          {
+            "node": "uProc35",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc35": {
+      "main": [
+        [
+          {
+            "node": "uProc36",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc36": {
+      "main": [
+        [
+          {
+            "node": "uProc37",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc37": {
+      "main": [
+        [
+          {
+            "node": "uProc38",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc38": {
+      "main": [
+        [
+          {
+            "node": "uProc39",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc39": {
+      "main": [
+        [
+          {
+            "node": "uProc40",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc40": {
+      "main": [
+        [
+          {
+            "node": "uProc41",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc41": {
+      "main": [
+        [
+          {
+            "node": "uProc42",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "uProc",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "uProc10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-20T13:25:03.086Z",
+  "updatedAt": "2021-04-20T15:03:32.741Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/177.json
+++ b/workflows/177.json
@@ -1,0 +1,723 @@
+{
+  "id": 177,
+  "name": "uProc:Finance:*;",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "checkCreditcardChecksum",
+        "credit_card": "5564456122310619",
+        "additionalOptions": {}
+      },
+      "name": "uProc1",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        510,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCreditcardType",
+        "credit_card": "5564456122310619",
+        "additionalOptions": {}
+      },
+      "name": "uProc2",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        640,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "checkBankAccountValidEs",
+        "account": "5564456122310619",
+        "additionalOptions": {}
+      },
+      "name": "uProc3",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        770,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "bic": "AYGBESMM",
+        "additionalOptions": {}
+      },
+      "name": "uProc4",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        900,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getBankIbanByAccount",
+        "account": "9121000418450200051332M",
+        "isocode": "ES",
+        "additionalOptions": {}
+      },
+      "name": "uProc5",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1030,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getBankIbanLookup",
+        "iban": "ES9121000418450200051332M",
+        "additionalOptions": {}
+      },
+      "name": "uProc6",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1160,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "checkBankIbanValid",
+        "iban": "ES9121000418450200051332M",
+        "additionalOptions": {}
+      },
+      "name": "uProc7",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1290,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyByCountry",
+        "country": "ES",
+        "additionalOptions": {}
+      },
+      "name": "uProc8",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1420,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyByCountryIsocode",
+        "country_code": "ES",
+        "additionalOptions": {}
+      },
+      "name": "uProc9",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1550,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc10",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1680,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyByIsocode",
+        "isocode": "ES",
+        "additionalOptions": {}
+      },
+      "name": "uProc11",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1810,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyConvertedBetweenIsocodeDate",
+        "date": "104.21.37.3",
+        "amount": "10",
+        "isocode1": "EUR",
+        "isocode2": "JPY",
+        "additionalOptions": {}
+      },
+      "name": "uProc12",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1940,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyListByCountry",
+        "additionalOptions": {}
+      },
+      "name": "uProc13",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2070,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyListByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc14",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2200,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getCurrencyListByIsocode",
+        "isocode": "DE",
+        "additionalOptions": {}
+      },
+      "name": "uProc15",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2330,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "checkCurrencyValidIso",
+        "isocode": "DE",
+        "additionalOptions": {}
+      },
+      "name": "uProc16",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2460,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByAddress",
+        "address": "10115, Berlin, Germany",
+        "additionalOptions": {}
+      },
+      "name": "uProc17",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2590,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByCoordinates",
+        "coordinates": "52.52986092913615, 13.389315284523297",
+        "additionalOptions": {}
+      },
+      "name": "uProc18",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2720,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc19",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2850,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByIsocode",
+        "isocode": "DE",
+        "additionalOptions": {}
+      },
+      "name": "uProc20",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2980,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByNumber",
+        "isocode": "DE",
+        "tin": "44016116G",
+        "additionalOptions": {}
+      },
+      "name": "uProc21",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3110,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByPhone",
+        "phone": "932187670",
+        "additionalOptions": {}
+      },
+      "name": "uProc22",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3240,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "getVatByZipcode",
+        "zipcode": "10115",
+        "additionalOptions": {}
+      },
+      "name": "uProc23",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3370,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "finance",
+        "tool": "checkVatExist",
+        "isocode": "ES",
+        "tin": "44016116G",
+        "additionalOptions": {}
+      },
+      "name": "uProc24",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3500,
+        290
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    }
+  ],
+  "connections": {
+    "uProc1": {
+      "main": [
+        [
+          {
+            "node": "uProc2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc2": {
+      "main": [
+        [
+          {
+            "node": "uProc3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc3": {
+      "main": [
+        [
+          {
+            "node": "uProc4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc4": {
+      "main": [
+        [
+          {
+            "node": "uProc5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc5": {
+      "main": [
+        [
+          {
+            "node": "uProc6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc6": {
+      "main": [
+        [
+          {
+            "node": "uProc7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc7": {
+      "main": [
+        [
+          {
+            "node": "uProc8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc8": {
+      "main": [
+        [
+          {
+            "node": "uProc9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc9": {
+      "main": [
+        [
+          {
+            "node": "uProc10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc10": {
+      "main": [
+        [
+          {
+            "node": "uProc11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc11": {
+      "main": [
+        [
+          {
+            "node": "uProc12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc12": {
+      "main": [
+        [
+          {
+            "node": "uProc13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc13": {
+      "main": [
+        [
+          {
+            "node": "uProc14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc14": {
+      "main": [
+        [
+          {
+            "node": "uProc15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc15": {
+      "main": [
+        [
+          {
+            "node": "uProc16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc16": {
+      "main": [
+        [
+          {
+            "node": "uProc17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc17": {
+      "main": [
+        [
+          {
+            "node": "uProc18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc18": {
+      "main": [
+        [
+          {
+            "node": "uProc19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc19": {
+      "main": [
+        [
+          {
+            "node": "uProc20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc20": {
+      "main": [
+        [
+          {
+            "node": "uProc21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc21": {
+      "main": [
+        [
+          {
+            "node": "uProc22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc22": {
+      "main": [
+        [
+          {
+            "node": "uProc23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc23": {
+      "main": [
+        [
+          {
+            "node": "uProc24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "uProc1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-20T15:07:09.205Z",
+  "updatedAt": "2021-04-20T15:15:49.518Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/179.json
+++ b/workflows/179.json
@@ -1,0 +1,317 @@
+{
+  "id": 179,
+  "name": "uProc:Image:*:Security:*;",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "group": "security",
+        "tool": "checkNumberUuid",
+        "uuid": "0c6a1543-6232-49d2-b50d-c1e70cd015a0",
+        "additionalOptions": {}
+      },
+      "name": "uProc1",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        450,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "security",
+        "tool": "getDomainBlacklists",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc2",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        580,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "security",
+        "tool": "getIpBlacklists",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc3",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        710,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "security",
+        "luhn": "79927398713",
+        "additionalOptions": {}
+      },
+      "name": "uProc4",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        840,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "security",
+        "tool": "checkPasswordStrong",
+        "password": "randompassword",
+        "additionalOptions": {}
+      },
+      "name": "uProc5",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        970,
+        350
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "image",
+        "tool": "getBarcodeEncoded",
+        "text": "n8n rocks!",
+        "bcid": "auspost",
+        "additionalOptions": {}
+      },
+      "name": "uProc",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        450,
+        150
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "image",
+        "tool": "getImageExif",
+        "url": "https://n8n.io/_nuxt/img/df5be1c.png",
+        "additionalOptions": {}
+      },
+      "name": "uProc8",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        840,
+        150
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "image",
+        "tool": "getImageWithText",
+        "text": "n8n rocks!",
+        "url": "https://n8n.io/_nuxt/img/df5be1c.png",
+        "size": "72",
+        "additionalOptions": {}
+      },
+      "name": "uProc9",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        970,
+        150
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "image",
+        "tool": "getDomainLogo",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc10",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        580,
+        150
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "image",
+        "tool": "getUrlScreenshot",
+        "url": "n8n.io",
+        "useragent": "n8n-agent",
+        "width": "160",
+        "fullpage": "no",
+        "additionalOptions": {}
+      },
+      "name": "uProc11",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        710,
+        150
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    }
+  ],
+  "connections": {
+    "uProc1": {
+      "main": [
+        [
+          {
+            "node": "uProc2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc2": {
+      "main": [
+        [
+          {
+            "node": "uProc3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc3": {
+      "main": [
+        [
+          {
+            "node": "uProc4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc4": {
+      "main": [
+        [
+          {
+            "node": "uProc5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc": {
+      "main": [
+        [
+          {
+            "node": "uProc10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc8": {
+      "main": [
+        [
+          {
+            "node": "uProc9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc9": {
+      "main": [
+        []
+      ]
+    },
+    "uProc10": {
+      "main": [
+        [
+          {
+            "node": "uProc11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc11": {
+      "main": [
+        [
+          {
+            "node": "uProc8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "uProc",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "uProc1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-21T07:53:05.959Z",
+  "updatedAt": "2021-04-21T07:53:05.959Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/180.json
+++ b/workflows/180.json
@@ -1,0 +1,1185 @@
+{
+  "id": 180,
+  "name": "uProc:Internet:*;",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDeviceByUa",
+        "useragent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36",
+        "additionalOptions": {}
+      },
+      "name": "uProc1",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        420,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlByDomain",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc2",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        550,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainByIp",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc3",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        680,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainByUrl",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc4",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        810,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkDomainCertificate",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc5",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        940,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainCertificate",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc6",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc7",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkDomainFormat",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc8",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1330,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainIsp",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc9",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1460,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkDomainMx",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc10",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1590,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlPdf",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc11",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1720,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkDomainRecord",
+        "domain": "n8n.io",
+        "type": "NS",
+        "additionalOptions": {}
+      },
+      "name": "uProc12",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1850,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainRecord",
+        "domain": "n8n.io",
+        "type": "NS",
+        "additionalOptions": {}
+      },
+      "name": "uProc13",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1980,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainRecords",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc14",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2110,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkDomainReverse",
+        "ip": "104.21.37.3",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc15",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2240,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainReverseIp",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc16",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2370,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlShareableLinks",
+        "text": "n8n rocks!",
+        "url": "https://n8n.io/",
+        "additionalOptions": {}
+      },
+      "name": "uProc17",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2500,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainTechnologies",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc18",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2630,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlTechnologies",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc19",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2760,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainVisits",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc20",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2890,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getDomainWhois",
+        "domain": "n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc21",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        3020,
+        300
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getIpWhois",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc22",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        420,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getFileCopiedBetweenUrls",
+        "source": "https://n8n.io/_nuxt/img/df5be1c.png",
+        "destination": "test",
+        "additionalOptions": {}
+      },
+      "name": "uProc23",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        550,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlAnalysis",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc24",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        680,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getNetAton",
+        "ip": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc25",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        810,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkUrlContains",
+        "url": "104.21.37.3",
+        "regex": "n8n",
+        "additionalOptions": {}
+      },
+      "name": "uProc26",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        940,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlContents",
+        "url": "https://n8n.io",
+        "selector": "h1",
+        "additionalOptions": {}
+      },
+      "name": "uProc27",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1070,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlContentsParsed",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc28",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlDecode",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc29",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1330,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlEncode",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc30",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1460,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkUrlExist",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc31",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1590,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getNetFixip",
+        "number": "104.21.37.3",
+        "additionalOptions": {}
+      },
+      "name": "uProc32",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1720,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkNetHostAlive",
+        "host": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc33",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1850,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlListContentsParsed",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc34",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        1980,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getNetNtoa",
+        "number": "10421373",
+        "additionalOptions": {}
+      },
+      "name": "uProc35",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2110,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlParsed",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc36",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2240,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getNetScan",
+        "host": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc37",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2370,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkNetServiceUp",
+        "host": "https://n8n.io",
+        "port": "80",
+        "additionalOptions": {}
+      },
+      "name": "uProc38",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2500,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "getUrlTables",
+        "url": "https://n8n.io",
+        "table": "3",
+        "additionalOptions": {}
+      },
+      "name": "uProc39",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2630,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    },
+    {
+      "parameters": {
+        "group": "internet",
+        "tool": "checkUrlValid",
+        "url": "https://n8n.io",
+        "additionalOptions": {}
+      },
+      "name": "uProc40",
+      "type": "n8n-nodes-base.uproc",
+      "typeVersion": 1,
+      "position": [
+        2760,
+        470
+      ],
+      "credentials": {
+        "uprocApi": "uProc API creds"
+      }
+    }
+  ],
+  "connections": {
+    "uProc1": {
+      "main": [
+        [
+          {
+            "node": "uProc2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc2": {
+      "main": [
+        [
+          {
+            "node": "uProc3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc3": {
+      "main": [
+        [
+          {
+            "node": "uProc4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc4": {
+      "main": [
+        [
+          {
+            "node": "uProc5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc5": {
+      "main": [
+        [
+          {
+            "node": "uProc6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc6": {
+      "main": [
+        [
+          {
+            "node": "uProc7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc7": {
+      "main": [
+        [
+          {
+            "node": "uProc8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc8": {
+      "main": [
+        [
+          {
+            "node": "uProc9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc9": {
+      "main": [
+        [
+          {
+            "node": "uProc10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc10": {
+      "main": [
+        [
+          {
+            "node": "uProc11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc11": {
+      "main": [
+        [
+          {
+            "node": "uProc12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc12": {
+      "main": [
+        [
+          {
+            "node": "uProc13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc13": {
+      "main": [
+        [
+          {
+            "node": "uProc14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc14": {
+      "main": [
+        [
+          {
+            "node": "uProc15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc15": {
+      "main": [
+        [
+          {
+            "node": "uProc16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc16": {
+      "main": [
+        [
+          {
+            "node": "uProc17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc17": {
+      "main": [
+        [
+          {
+            "node": "uProc18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc18": {
+      "main": [
+        [
+          {
+            "node": "uProc19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc19": {
+      "main": [
+        [
+          {
+            "node": "uProc20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc20": {
+      "main": [
+        [
+          {
+            "node": "uProc21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc22": {
+      "main": [
+        [
+          {
+            "node": "uProc23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc23": {
+      "main": [
+        [
+          {
+            "node": "uProc24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc24": {
+      "main": [
+        [
+          {
+            "node": "uProc25",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc25": {
+      "main": [
+        [
+          {
+            "node": "uProc26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc26": {
+      "main": [
+        [
+          {
+            "node": "uProc27",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc27": {
+      "main": [
+        [
+          {
+            "node": "uProc28",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc28": {
+      "main": [
+        [
+          {
+            "node": "uProc29",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc29": {
+      "main": [
+        [
+          {
+            "node": "uProc30",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc30": {
+      "main": [
+        [
+          {
+            "node": "uProc31",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc31": {
+      "main": [
+        [
+          {
+            "node": "uProc32",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc32": {
+      "main": [
+        [
+          {
+            "node": "uProc33",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc33": {
+      "main": [
+        [
+          {
+            "node": "uProc34",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc34": {
+      "main": [
+        [
+          {
+            "node": "uProc35",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc35": {
+      "main": [
+        [
+          {
+            "node": "uProc36",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc36": {
+      "main": [
+        [
+          {
+            "node": "uProc37",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc37": {
+      "main": [
+        [
+          {
+            "node": "uProc38",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc38": {
+      "main": [
+        [
+          {
+            "node": "uProc39",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "uProc39": {
+      "main": [
+        [
+          {
+            "node": "uProc40",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "uProc1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "uProc22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-21T08:02:44.895Z",
+  "updatedAt": "2021-04-21T08:23:47.669Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes workflows to test the uProc node

Note: the uProc node include 430 operations in total, in which the node interact with the same API endpoint, thus for testing we will use a subset of the operations

Workflow n°176 support:
- Audio: *
- Company: *

Workflow n°177 support:
- Finance: *

Workflow n°179 support:
- Image: *
- Security: *

Workflow n°180 support:
- Internet: *