### PR TITLE
Add test workflows for Salesforce node

### DIFF
--- a/workflows/184.json
+++ b/workflows/184.json
@@ -1,0 +1,650 @@
+{
+  "id": 184,
+  "name": "Salesforce:Account:create get addNote getAll getSummary update delete:Case:create get addComment getAll getSummary update delete:Attachment:create get getAll getSummary update delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "name": "=Account{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Salesforce",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        520,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "get",
+        "accountId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce1",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        680,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "addNote",
+        "accountId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "title": "=Note{{Date.now()}}",
+        "options": {}
+      },
+      "name": "Salesforce2",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        840,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce3",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce4",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "update",
+        "accountId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "=Updated{{$node[\"Salesforce1\"].json[\"Name\"]}}"
+        }
+      },
+      "name": "Salesforce5",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1300,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "account",
+        "operation": "delete",
+        "accountId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce6",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1450,
+        190
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "type": "Other",
+        "additionalFields": {
+          "reason": "Installation",
+          "subject": "=Subject{{Date.now()}}"
+        }
+      },
+      "name": "Salesforce7",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        530,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "get",
+        "caseId": "={{$node[\"Salesforce7\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce8",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        690,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "addComment",
+        "caseId": "={{$node[\"Salesforce7\"].json[\"id\"]}}",
+        "options": {
+          "commentBody": "=Comment{{Date.now()}}"
+        }
+      },
+      "name": "Salesforce9",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        2000,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce10",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        2160,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce11",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        2320,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "update",
+        "caseId": "={{$node[\"Salesforce7\"].json[\"id\"]}}",
+        "updateFields": {
+          "subject": "=Updated{{$node[\"Salesforce8\"].json[\"Subject\"]}}"
+        }
+      },
+      "name": "Salesforce12",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        2510,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "case",
+        "operation": "delete",
+        "caseId": "={{$node[\"Salesforce7\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce13",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        2670,
+        350
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "parentId": "={{$node[\"Salesforce8\"].json[\"Id\"]}}",
+        "name": "=Attachment{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Salesforce14",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "data",
+              "value": "=Attachment example"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [
+        800,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "jsonToBinary",
+        "options": {}
+      },
+      "name": "Move Binary Data",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1,
+      "position": [
+        960,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "operation": "get",
+        "attachmentId": "={{$node[\"Salesforce14\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce15",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce16",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1400,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce17",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1550,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "operation": "update",
+        "attachmentId": "={{$node[\"Salesforce14\"].json[\"id\"]}}",
+        "updateFields": {
+          "isPrivate": true
+        }
+      },
+      "name": "Salesforce18",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1700,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "attachment",
+        "operation": "delete",
+        "attachmentId": "={{$node[\"Salesforce14\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce19",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1850,
+        500
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Salesforce": {
+      "main": [
+        [
+          {
+            "node": "Salesforce1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce1": {
+      "main": [
+        [
+          {
+            "node": "Salesforce2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce2": {
+      "main": [
+        [
+          {
+            "node": "Salesforce3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce3": {
+      "main": [
+        [
+          {
+            "node": "Salesforce4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce4": {
+      "main": [
+        [
+          {
+            "node": "Salesforce5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce5": {
+      "main": [
+        [
+          {
+            "node": "Salesforce6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce7": {
+      "main": [
+        [
+          {
+            "node": "Salesforce8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce8": {
+      "main": [
+        [
+          {
+            "node": "Set",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce9": {
+      "main": [
+        [
+          {
+            "node": "Salesforce10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce10": {
+      "main": [
+        [
+          {
+            "node": "Salesforce11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce11": {
+      "main": [
+        [
+          {
+            "node": "Salesforce12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce12": {
+      "main": [
+        [
+          {
+            "node": "Salesforce13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set": {
+      "main": [
+        [
+          {
+            "node": "Move Binary Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Move Binary Data": {
+      "main": [
+        [
+          {
+            "node": "Salesforce14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce14": {
+      "main": [
+        [
+          {
+            "node": "Salesforce15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce15": {
+      "main": [
+        [
+          {
+            "node": "Salesforce16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce16": {
+      "main": [
+        [
+          {
+            "node": "Salesforce17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce17": {
+      "main": [
+        [
+          {
+            "node": "Salesforce18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce18": {
+      "main": [
+        [
+          {
+            "node": "Salesforce19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce19": {
+      "main": [
+        [
+          {
+            "node": "Salesforce9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Salesforce7",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-26T16:15:15.635Z",
+  "updatedAt": "2021-04-26T17:54:35.464Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/185.json
+++ b/workflows/185.json
@@ -1,0 +1,676 @@
+{
+  "id": 185,
+  "name": "Salesforce:Lead:create get addNote addToCampaign getAll getSummary update delete:Contact:create get addNote addToCampaign getAll getSummary update delete:CustomObject:create get getAll update delete:Flow:getAll",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "lastname": "=Contact{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Salesforce",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        450,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "get",
+        "contactId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce1",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        600,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "addNote",
+        "contactId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "title": "=Note{{Date.now()}}",
+        "options": {}
+      },
+      "name": "Salesforce2",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        750,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce3",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        900,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce4",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "addToCampaign",
+        "contactId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "campaignId": "70109000000TU12AAG",
+        "options": {}
+      },
+      "name": "Salesforce5",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "update",
+        "contactId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "updateFields": {
+          "title": "=UpdatedTitle{{Date.now()}}"
+        }
+      },
+      "name": "Salesforce6",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "delete",
+        "contactId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce7",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1500,
+        230
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customObject",
+        "customObject": "CustomObjectFixed__c",
+        "customFieldsUi": {
+          "customFieldsValues": [
+            {
+              "fieldId": "Name",
+              "value": "TestCustomObjectFixed"
+            }
+          ]
+        }
+      },
+      "name": "Salesforce8",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        460,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customObject",
+        "operation": "get",
+        "customObject": "CustomObjectFixed__c",
+        "recordId": "={{$node[\"Salesforce8\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce9",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        600,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customObject",
+        "operation": "getAll",
+        "customObject": "CustomObjectFixed__c",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce10",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        750,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customObject",
+        "operation": "update",
+        "customObject": "CustomObjectFixed__c",
+        "recordId": "={{$node[\"Salesforce8\"].json[\"id\"]}}",
+        "customFieldsUi": {
+          "customFieldsValues": [
+            {
+              "fieldId": "Name",
+              "value": "UpdatedCustomObjectFixed"
+            }
+          ]
+        }
+      },
+      "name": "Salesforce11",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        900,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customObject",
+        "operation": "delete",
+        "customObject": "CustomObjectFixed__c",
+        "recordId": "={{$node[\"Salesforce8\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce12",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "flow",
+        "operation": "getAll",
+        "limit": 1
+      },
+      "name": "Salesforce13",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        460,
+        560
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "flow",
+        "apiName": "={{$node[\"Salesforce13\"].json[\"name\"]}}"
+      },
+      "name": "Salesforce14",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        600,
+        560
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "company": "n8n",
+        "lastname": "=LastName{{Date.now()}}",
+        "additionalFields": {}
+      },
+      "name": "Salesforce15",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        450,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "leadId": "={{$node[\"Salesforce15\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce16",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        600,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "addNote",
+        "leadId": "={{$node[\"Salesforce15\"].json[\"id\"]}}",
+        "title": "LeadNote",
+        "options": {}
+      },
+      "name": "Salesforce17",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        750,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getSummary"
+      },
+      "name": "Salesforce18",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        900,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce19",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "addToCampaign",
+        "leadId": "={{$node[\"Salesforce15\"].json[\"id\"]}}",
+        "campaignId": "70109000000TU12AAG",
+        "options": {}
+      },
+      "name": "Salesforce20",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "leadId": "={{$node[\"Salesforce15\"].json[\"id\"]}}",
+        "updateFields": {
+          "description": "Updated Description"
+        }
+      },
+      "name": "Salesforce21",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1350,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "leadId": "={{$node[\"Salesforce15\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce22",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1500,
+        50
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Salesforce": {
+      "main": [
+        [
+          {
+            "node": "Salesforce1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce1": {
+      "main": [
+        [
+          {
+            "node": "Salesforce2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce2": {
+      "main": [
+        [
+          {
+            "node": "Salesforce3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce3": {
+      "main": [
+        [
+          {
+            "node": "Salesforce4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce4": {
+      "main": [
+        [
+          {
+            "node": "Salesforce5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce5": {
+      "main": [
+        [
+          {
+            "node": "Salesforce6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce6": {
+      "main": [
+        [
+          {
+            "node": "Salesforce7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Salesforce",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce8",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce13",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce8": {
+      "main": [
+        [
+          {
+            "node": "Salesforce9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce9": {
+      "main": [
+        [
+          {
+            "node": "Salesforce10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce10": {
+      "main": [
+        [
+          {
+            "node": "Salesforce11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce11": {
+      "main": [
+        [
+          {
+            "node": "Salesforce12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce13": {
+      "main": [
+        [
+          {
+            "node": "Salesforce14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce15": {
+      "main": [
+        [
+          {
+            "node": "Salesforce16",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce16": {
+      "main": [
+        [
+          {
+            "node": "Salesforce17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce17": {
+      "main": [
+        [
+          {
+            "node": "Salesforce18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce18": {
+      "main": [
+        [
+          {
+            "node": "Salesforce19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce19": {
+      "main": [
+        [
+          {
+            "node": "Salesforce20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce20": {
+      "main": [
+        [
+          {
+            "node": "Salesforce21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce21": {
+      "main": [
+        [
+          {
+            "node": "Salesforce22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-26T16:57:16.077Z",
+  "updatedAt": "2021-04-26T17:56:22.317Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/186.json
+++ b/workflows/186.json
@@ -1,0 +1,412 @@
+{
+  "id": 186,
+  "name": "Salesforce:Opportunity:create get addNote getAll getSummary update delete:Task:create get getAll getSummary update delete:Query:search",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "name": "=Opp{{Date.now()}}",
+        "closeDate": "2021-03-31T22:00:00.000Z",
+        "stageName": "Value Proposition",
+        "additionalFields": {}
+      },
+      "name": "Salesforce",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        500,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "get",
+        "opportunityId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce1",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        650,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "addNote",
+        "opportunityId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "title": "OppNote",
+        "options": {}
+      },
+      "name": "Salesforce2",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        800,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce3",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        950,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce4",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "update",
+        "opportunityId": "={{$node[\"Salesforce\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "UpdatedOpp"
+        }
+      },
+      "name": "Salesforce5",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "delete",
+        "opportunityId": "={{$node[\"Salesforce\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce6",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1400,
+        250
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "search",
+        "query": "SELECT Id, Name, BillingCity FROM Account LIMIT 1"
+      },
+      "name": "Salesforce7",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        500,
+        400
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "status": "In Progress",
+        "additionalFields": {}
+      },
+      "name": "Salesforce8",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        500,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "get",
+        "taskId": "={{$node[\"Salesforce8\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce9",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        650,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "getSummary"
+      },
+      "name": "Salesforce10",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        800,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Salesforce11",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        950,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "update",
+        "taskId": "={{$node[\"Salesforce8\"].json[\"id\"]}}",
+        "updateFields": {
+          "status": "Completed"
+        }
+      },
+      "name": "Salesforce12",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "delete",
+        "taskId": "={{$node[\"Salesforce8\"].json[\"id\"]}}"
+      },
+      "name": "Salesforce13",
+      "type": "n8n-nodes-base.salesforce",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        550
+      ],
+      "credentials": {
+        "salesforceOAuth2Api": "Salesforce OAuth2 API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Salesforce": {
+      "main": [
+        [
+          {
+            "node": "Salesforce1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce1": {
+      "main": [
+        [
+          {
+            "node": "Salesforce2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce2": {
+      "main": [
+        [
+          {
+            "node": "Salesforce3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce3": {
+      "main": [
+        [
+          {
+            "node": "Salesforce4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce4": {
+      "main": [
+        [
+          {
+            "node": "Salesforce5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce5": {
+      "main": [
+        [
+          {
+            "node": "Salesforce6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Salesforce",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce8",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Salesforce7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce8": {
+      "main": [
+        [
+          {
+            "node": "Salesforce9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce9": {
+      "main": [
+        [
+          {
+            "node": "Salesforce10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce10": {
+      "main": [
+        [
+          {
+            "node": "Salesforce11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce11": {
+      "main": [
+        [
+          {
+            "node": "Salesforce12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Salesforce12": {
+      "main": [
+        [
+          {
+            "node": "Salesforce13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-04-26T17:42:22.794Z",
+  "updatedAt": "2021-04-26T17:58:02.439Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflows to test the Salesforce node

Workflow n°184 support:

- Account: create get addNote getAll getSummary update delete
- Case: create get addComment getAll getSummary update delete
- Attachment: create get getAll getSummary update delete

Workflow n°185 support:

- Lead: create get addNote addToCampaign getAll getSummary update delete
- Contact: create get addNote addToCampaign getAll getSummary update delete
- CustomObject: create get getAll update delete
- Flow: getAll

Workflow n°186 support:

- Opportunity: create get addNote getAll getSummary update delete
- Task: create get getAll getSummary update delete
- Query: search

Note: the workflow doesn't  n°185 support  `invoke:flow` (WIP)