### PR TITLE
Add test workflow for Pipedrive node

### DIFF
--- a/workflows/200.json
+++ b/workflows/200.json
@@ -1,0 +1,985 @@
+{
+  "id": 200,
+  "name": "Pipedrive:Activity:create get update getAll delete:Deal:create get update duplicate getAll delete:Person:create get update getAll search delete:File:create get download delete:Organization:create get update getAll delete:Note:create get update getAll delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "activity",
+        "subject": "=Activity{{(new Date).toISOString()}}",
+        "type": "meeting",
+        "additionalFields": {}
+      },
+      "name": "Pipedrive",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        200
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "activity",
+        "operation": "get",
+        "activityId": "={{$node[\"Pipedrive\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive1",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        650,
+        200
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "activity",
+        "operation": "update",
+        "activityId": "={{$node[\"Pipedrive\"].json[\"id\"]}}",
+        "updateFields": {
+          "done": "1",
+          "note": "Used for testing",
+          "subject": "=Updated{{$node[\"Pipedrive\"].json[\"subject\"]}}",
+          "type": "call"
+        }
+      },
+      "name": "Pipedrive2",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        200
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "activity",
+        "operation": "getAll",
+        "limit": 1
+      },
+      "name": "Pipedrive3",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        950,
+        200
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "activity",
+        "operation": "delete",
+        "activityId": "={{$node[\"Pipedrive\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive4",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        200
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "title": "=Deal{{(new Date).toISOString()}}",
+        "additionalFields": {
+          "status": "open"
+        }
+      },
+      "name": "Pipedrive5",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "dealId": "={{$node[\"Pipedrive5\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive6",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        650,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "dealId": "={{$node[\"Pipedrive5\"].json[\"id\"]}}",
+        "updateFields": {
+          "status": "won",
+          "title": "=Updated{{$node[\"Pipedrive5\"].json[\"title\"]}}"
+        }
+      },
+      "name": "Pipedrive7",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "duplicate",
+        "dealId": "={{$node[\"Pipedrive5\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive8",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        950,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1
+      },
+      "name": "Pipedrive9",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "dealId": "={{$node[\"Pipedrive5\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive10",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "dealId": "={{$node[\"Pipedrive8\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive11",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1400,
+        350
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "additionalFields": {}
+      },
+      "name": "Pipedrive12",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        500
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "values": {
+          "number": [],
+          "string": [
+            {
+              "name": "file",
+              "value": "=Testing file"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [
+        500,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "jsonToBinary",
+        "convertAllData": false,
+        "sourceKey": "file",
+        "options": {
+          "fileName": "testFile",
+          "mimeType": "text"
+        }
+      },
+      "name": "Move Binary Data",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1,
+      "position": [
+        650,
+        500
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "get",
+        "fileId": "={{$node[\"Pipedrive12\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive13",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        950,
+        500
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "download",
+        "fileId": "={{$node[\"Pipedrive12\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive14",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        500
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "delete",
+        "fileId": "={{$node[\"Pipedrive12\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive15",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        500
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "organization",
+        "name": "=Organization_{{(new Date).toISOString()}}",
+        "additionalFields": {
+          "label": 3
+        }
+      },
+      "name": "Pipedrive16",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        650
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "organization",
+        "operation": "get",
+        "organizationId": "={{$node[\"Pipedrive16\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive17",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        670,
+        650
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "organization",
+        "operation": "update",
+        "organizationId": "={{$node[\"Pipedrive16\"].json[\"id\"]}}",
+        "updateFields": {
+          "label": 2,
+          "name": "=Updated{{$node[\"Pipedrive16\"].json[\"name\"]}}",
+          "visible_to": "3"
+        }
+      },
+      "name": "Pipedrive18",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        820,
+        650
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "organization",
+        "operation": "getAll",
+        "limit": 1
+      },
+      "name": "Pipedrive19",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        970,
+        650
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "organization",
+        "operation": "delete",
+        "organizationId": "={{$node[\"Pipedrive16\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive20",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1120,
+        650
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "note",
+        "content": "=Note_{{(new Date).toISOString()}}",
+        "additionalFields": {
+          "org_id": "={{$node[\"Pipedrive16\"].json[\"id\"]}}"
+        }
+      },
+      "name": "Pipedrive21",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        650,
+        800
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "note",
+        "operation": "get",
+        "noteId": "={{$node[\"Pipedrive21\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive22",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        800
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "note",
+        "operation": "update",
+        "noteId": "={{$node[\"Pipedrive21\"].json[\"id\"]}}",
+        "updateFields": {
+          "content": "=Updated{{$node[\"Pipedrive21\"].json[\"content\"]}}"
+        }
+      },
+      "name": "Pipedrive23",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        950,
+        800
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "note",
+        "operation": "getAll",
+        "additionalFields": {},
+        "limit": 1
+      },
+      "name": "Pipedrive24",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        800
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "note",
+        "operation": "delete",
+        "noteId": "={{$node[\"Pipedrive21\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive25",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        800
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "name": "=Person_{{(new Date).toISOString()}}",
+        "additionalFields": {
+          "label": 1,
+          "visible_to": "3"
+        }
+      },
+      "name": "Pipedrive26",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        500,
+        50
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "get",
+        "personId": "={{$node[\"Pipedrive26\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive27",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        650,
+        50
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "update",
+        "personId": "={{$node[\"Pipedrive26\"].json[\"id\"]}}",
+        "updateFields": {
+          "label": 2,
+          "name": "=Updated{{$node[\"Pipedrive31302926\"].json[\"first_name\"]}}"
+        }
+      },
+      "name": "Pipedrive28",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        800,
+        50
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "getAll",
+        "limit": 1,
+        "additionalFields": {}
+      },
+      "name": "Pipedrive29",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        950,
+        50
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "search",
+        "limit": 1,
+        "term": "updated",
+        "additionalFields": {}
+      },
+      "name": "Pipedrive30",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        50
+      ],
+      "alwaysOutputData": true,
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "delete",
+        "personId": "={{$node[\"Pipedrive26\"].json[\"id\"]}}"
+      },
+      "name": "Pipedrive31",
+      "type": "n8n-nodes-base.pipedrive",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        50
+      ],
+      "credentials": {
+        "pipedriveApi": "Pipedrive API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Pipedrive": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive1": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive2": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive3": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Pipedrive5",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Set",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Pipedrive16",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Pipedrive26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive5": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive6": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive7": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive8": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive9": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive10": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set": {
+      "main": [
+        [
+          {
+            "node": "Move Binary Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Move Binary Data": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive12": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive13": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive14": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive16": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive17": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive18": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive19": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive21": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive22": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive23": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive24": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive25",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive25": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive26": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive27",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive27": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive28",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive28": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive29",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive29": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive30",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pipedrive30": {
+      "main": [
+        [
+          {
+            "node": "Pipedrive31",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-05-11T07:41:09.199Z",
+  "updatedAt": "2021-05-11T08:09:44.364Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Pipedrive node

Workflow n°200 support:

- Activity: create get update getAll delete
- Deal: create get update duplicate getAll delete
- Person: create get update getAll search delete
- File: create get download delete
- Organization: create get update getAll delete
- Note: create get update getAll delete

Note : this workflow doesn't support the `getAll:Product` operation (Advanced plan)