### PR TITLE
Add test workflows for Keap node

### DIFF
--- a/workflows/206.json
+++ b/workflows/206.json
@@ -1,0 +1,428 @@
+{
+  "id": 206,
+  "name": "Keap:Company:create getAll:Contact:upsert get getAll delete:ContactNote:create get update getAll delete:ContactTag:create getAll delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "companyName": "=Company_{{(new Date).toISOString()}}",
+        "additionalFields": {}
+      },
+      "name": "Keap",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        600,
+        200
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Keap1",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        750,
+        200
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "additionalFields": {
+          "companyId": "={{$node[\"Keap\"].json[\"id\"]}}"
+        },
+        "addressesUi": {
+          "addressesValues": []
+        },
+        "emailsUi": {
+          "emailsValues": [
+            {
+              "field": "EMAIL1",
+              "email": "=fakeemail{{Date.now()}}@test.com"
+            }
+          ]
+        }
+      },
+      "name": "Keap2",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        750,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "get",
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}",
+        "options": {}
+      },
+      "name": "Keap3",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        900,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Keap4",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1040,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "operation": "delete",
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}"
+      },
+      "name": "Keap5",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactNote",
+        "userId": 1,
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}",
+        "additionalFields": {
+          "body": "",
+          "title": "=Note{Date.now()}}"
+        }
+      },
+      "name": "Keap6",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        900,
+        510
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactNote",
+        "operation": "get",
+        "noteId": "={{$node[\"Keap6\"].json[\"id\"]}}"
+      },
+      "name": "Keap7",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        510
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactNote",
+        "operation": "update",
+        "noteId": "={{$node[\"Keap6\"].json[\"id\"]}}",
+        "additionalFields": {
+          "title": "Updated Title"
+        }
+      },
+      "name": "Keap8",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        510
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactNote",
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Keap9",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1360,
+        510
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactNote",
+        "operation": "delete",
+        "noteId": "={{$node[\"Keap6\"].json[\"id\"]}}"
+      },
+      "name": "Keap10",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1500,
+        510
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactTag",
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}",
+        "tagIds": [
+          93
+        ]
+      },
+      "name": "Keap11",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        900,
+        660
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactTag",
+        "operation": "getAll",
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}",
+        "limit": 1
+      },
+      "name": "Keap12",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        660
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "contactTag",
+        "operation": "delete",
+        "contactId": "={{$node[\"Keap2\"].json[\"id\"]}}",
+        "tagIds": "93,"
+      },
+      "name": "Keap13",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1190,
+        660
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Keap": {
+      "main": [
+        [
+          {
+            "node": "Keap1",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Keap2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap2": {
+      "main": [
+        [
+          {
+            "node": "Keap6",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Keap11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap3": {
+      "main": [
+        [
+          {
+            "node": "Keap4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap4": {
+      "main": [
+        [
+          {
+            "node": "Keap5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap6": {
+      "main": [
+        [
+          {
+            "node": "Keap7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap7": {
+      "main": [
+        [
+          {
+            "node": "Keap8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap8": {
+      "main": [
+        [
+          {
+            "node": "Keap9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap9": {
+      "main": [
+        [
+          {
+            "node": "Keap10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap10": {
+      "main": [
+        [
+          {
+            "node": "Keap3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap11": {
+      "main": [
+        [
+          {
+            "node": "Keap12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap12": {
+      "main": [
+        [
+          {
+            "node": "Keap13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Keap",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-05-17T15:09:40.220Z",
+  "updatedAt": "2021-05-18T07:57:05.962Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/207.json
+++ b/workflows/207.json
@@ -1,0 +1,465 @@
+{
+  "id": 207,
+  "name": "Keap:EcommerceOrder:create get getAll delete:EcommerceProduct:create get getAll delete:Email:createRecord getAll:File:upload getAll delete",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceProduct",
+        "productName": "=Producct_{{(new Date).toISOString()}}",
+        "additionalFields": {}
+      },
+      "name": "Keap",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        650,
+        180
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceProduct",
+        "operation": "get",
+        "productId": "={{$node[\"Keap\"].json[\"id\"]}}"
+      },
+      "name": "Keap1",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        810,
+        180
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceProduct",
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Keap2",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        970,
+        180
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceProduct",
+        "operation": "delete",
+        "productId": "={{$node[\"Keap\"].json[\"id\"]}}"
+      },
+      "name": "Keap3",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1120,
+        180
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "sentToAddress": "test@gmail.com",
+        "sentFromAddress": "fromtest@gmail.com",
+        "additionalFields": {}
+      },
+      "name": "Keap4",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        650,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Keap5",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        800,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "email",
+        "operation": "send",
+        "userId": 1,
+        "contactIds": "={{$node[\"Keap7\"].json[\"id\"]}},",
+        "subject": "Test",
+        "additionalFields": {
+          "addressField": "node8qa@gmail.com,",
+          "plainContent": "Text content"
+        }
+      },
+      "name": "Keap6",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        950,
+        350
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      },
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "resource": "contact",
+        "additionalFields": {},
+        "emailsUi": {
+          "emailsValues": [
+            {
+              "field": "EMAIL1",
+              "email": "node8qa@gmail.com"
+            }
+          ]
+        }
+      },
+      "name": "Keap7",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        490,
+        280
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceOrder",
+        "contactId": "={{$node[\"Keap7\"].json[\"id\"]}}",
+        "orderDate": "2021-05-18T07:35:03.000Z",
+        "orderTitle": "=Title{{Date.now()}}",
+        "orderType": "offline",
+        "additionalFields": {},
+        "orderItemsUi": {
+          "orderItemsValues": [
+            {
+              "description": "testing",
+              "price": 6,
+              "product ID": "={{$node[\"Keap\"].json[\"id\"]}}",
+              "quantity": 3
+            }
+          ]
+        }
+      },
+      "name": "Keap8",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        810,
+        30
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceOrder",
+        "operation": "get",
+        "orderId": "={{$node[\"Keap8\"].json[\"id\"]}}"
+      },
+      "name": "Keap9",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        970,
+        30
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceOrder",
+        "operation": "getAll",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Keap10",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1130,
+        30
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "ecommerceOrder",
+        "operation": "delete",
+        "orderId": "={{$node[\"Keap8\"].json[\"id\"]}}"
+      },
+      "name": "Keap11",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        1290,
+        30
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "upload",
+        "fileAssociation": "contact",
+        "contactId": "={{$node[\"Keap7\"].json[\"id\"]}}",
+        "fileName": "test.csv",
+        "fileData": "IyB0aGlzIGlzIGEgdGVzdCBmaWxl"
+      },
+      "name": "Keap12",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        650,
+        520
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {}
+      },
+      "name": "Keap13",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        810,
+        520
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "fileId": "={{$node[\"Keap12\"].json[\"file_descriptor\"][\"id\"]}}"
+      },
+      "name": "Keap14",
+      "type": "n8n-nodes-base.keap",
+      "typeVersion": 1,
+      "position": [
+        970,
+        520
+      ],
+      "credentials": {
+        "keapOAuth2Api": "Keap OAuth2 API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Keap": {
+      "main": [
+        [
+          {
+            "node": "Keap8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap1": {
+      "main": [
+        [
+          {
+            "node": "Keap2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap2": {
+      "main": [
+        [
+          {
+            "node": "Keap3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap4": {
+      "main": [
+        [
+          {
+            "node": "Keap5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap5": {
+      "main": [
+        [
+          {
+            "node": "Keap6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap7": {
+      "main": [
+        [
+          {
+            "node": "Keap",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Keap4",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Keap12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap8": {
+      "main": [
+        [
+          {
+            "node": "Keap9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap9": {
+      "main": [
+        [
+          {
+            "node": "Keap10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap10": {
+      "main": [
+        [
+          {
+            "node": "Keap11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap11": {
+      "main": [
+        [
+          {
+            "node": "Keap1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Keap7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap12": {
+      "main": [
+        [
+          {
+            "node": "Keap13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Keap13": {
+      "main": [
+        [
+          {
+            "node": "Keap14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-05-17T22:14:56.419Z",
+  "updatedAt": "2021-05-18T07:56:45.273Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes two workflows to test the Keap node

Workflow n°206 support:

- Company: create getAll
- Contact: upsert get getAll delete
- ContactNote: create get update getAll delete
- ContactTag: create getAll delete

Workflow n°207 support:

- EcommerceOrder: create get getAll delete
- EcommerceProduct: create get getAll delete
- Email: createRecord getAll
- File: upload getAll delete

Note: workflow 207 doesn't support `send:Email` operation