### PR TITLE
Discourse - fix workflow error

### DIFF
--- a/workflows/190.json
+++ b/workflows/190.json
@@ -237,9 +237,11 @@
         650,
         100
       ],
+      "alwaysOutputData": true,
       "credentials": {
         "discourseApi": "Discourse API"
-      }
+      },
+      "continueOnFail": true
     },
     {
       "parameters": {
@@ -481,7 +483,7 @@
     }
   },
   "createdAt": "2021-04-29T10:21:23.768Z",
-  "updatedAt": "2021-04-29T10:21:23.768Z",
+  "updatedAt": "2021-05-25T13:56:56.035Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr enable the continue on error & return data on node Discourse12

Note: the problem is related to a threshold of maximum created user from a single IP address, in that case `create:User` node doesn't error out, but the `get:User` node due to not found user. So enabling the continue on error option mitigate the problem.