### PR TITLE
Fix/Limit Stackby list results to one

### DIFF
--- a/workflows/171.json
+++ b/workflows/171.json
@@ -79,6 +79,8 @@
         "operation": "list",
         "stackId": "stOgji6AOGIluLfusu",
         "table": "TestTable",
+        "returnAll": false,
+        "limit": 1,
         "additionalFields": {
           "view": ""
         }
@@ -171,7 +173,7 @@
     }
   },
   "createdAt": "2021-04-19T10:15:58.189Z",
-  "updatedAt": "2021-04-19T10:15:58.189Z",
+  "updatedAt": "2021-06-01T09:55:06.720Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This PR fixed the `Delete` operation issue by limiting the `List` operation results to one single item.