### PR TITLE
Add test workflow for SSH node

### DIFF
--- a/snapshots/211-snapshot.json
+++ b/snapshots/211-snapshot.json
@@ -5,7 +5,7 @@
       "runData": {
         "Start": [
           {
-            "startTime": 1623772942062,
+            "startTime": 1626268048657,
             "executionTime": 1,
             "data": {
               "main": [
@@ -20,8 +20,8 @@
         ],
         "SSH": [
           {
-            "startTime": 1623772942064,
-            "executionTime": 1108,
+            "startTime": 1626268048659,
+            "executionTime": 923,
             "data": {
               "main": [
                 [
@@ -44,14 +44,14 @@
         ],
         "Set": [
           {
-            "startTime": 1623772943173,
-            "executionTime": 5,
+            "startTime": 1626268049584,
+            "executionTime": 6,
             "data": {
               "main": [
                 [
                   {
                     "json": {
-                      "name": "Tue Jun 15 2021 18:02:23 GMT+0200 (Central European Summer Time)"
+                      "name": "Wed Jul 14 2021 15:07:29 GMT+0200 (Central European Summer Time)"
                     }
                   }
                 ]
@@ -61,8 +61,8 @@
         ],
         "Move Binary Data": [
           {
-            "startTime": 1623772943178,
-            "executionTime": 2,
+            "startTime": 1626268049591,
+            "executionTime": 1,
             "data": {
               "main": [
                 [
@@ -70,7 +70,7 @@
                     "json": {},
                     "binary": {
                       "data": {
-                        "data": "IlR1ZSBKdW4gMTUgMjAyMSAxODowMjoyMyBHTVQrMDIwMCAoQ2VudHJhbCBFdXJvcGVhbiBTdW1tZXIgVGltZSki",
+                        "data": "IldlZCBKdWwgMTQgMjAyMSAxNTowNzoyOSBHTVQrMDIwMCAoQ2VudHJhbCBFdXJvcGVhbiBTdW1tZXIgVGltZSki",
                         "mimeType": "text"
                       }
                     }
@@ -82,8 +82,8 @@
         ],
         "SSH1": [
           {
-            "startTime": 1623772943180,
-            "executionTime": 1268,
+            "startTime": 1626268049593,
+            "executionTime": 1306,
             "data": {
               "main": [
                 [
@@ -99,8 +99,8 @@
         ],
         "SSH2": [
           {
-            "startTime": 1623772944450,
-            "executionTime": 1,
+            "startTime": 1626268050900,
+            "executionTime": 0,
             "data": {
               "main": [
                 [
@@ -124,7 +124,7 @@
     }
   },
   "mode": "cli",
-  "startedAt": "2021-06-15T16:02:22.060Z",
-  "stoppedAt": "2021-06-15T16:02:24.452Z",
+  "startedAt": "2021-07-14T13:07:28.655Z",
+  "stoppedAt": "2021-07-14T13:07:30.901Z",
   "finished": true
 }

--- a/snapshots/211-snapshot.json
+++ b/snapshots/211-snapshot.json
@@ -1,0 +1,130 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "Start": [
+          {
+            "startTime": 1623772942062,
+            "executionTime": 1,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {}
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "SSH": [
+          {
+            "startTime": 1623772942064,
+            "executionTime": 1108,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "code": {
+                        "object": true
+                      },
+                      "signal": {
+                        "object": true
+                      },
+                      "stdout": "nodeqa",
+                      "stderr": ""
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Set": [
+          {
+            "startTime": 1623772943173,
+            "executionTime": 5,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "name": "Tue Jun 15 2021 18:02:23 GMT+0200 (Central European Summer Time)"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Move Binary Data": [
+          {
+            "startTime": 1623772943178,
+            "executionTime": 2,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {},
+                    "binary": {
+                      "data": {
+                        "data": "IlR1ZSBKdW4gMTUgMjAyMSAxODowMjoyMyBHTVQrMDIwMCAoQ2VudHJhbCBFdXJvcGVhbiBTdW1tZXIgVGltZSki",
+                        "mimeType": "text"
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "SSH1": [
+          {
+            "startTime": 1623772943180,
+            "executionTime": 1268,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "SSH2": [
+          {
+            "startTime": 1623772944450,
+            "executionTime": 1,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "SSH2"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "waitingExecution": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2021-06-15T16:02:22.060Z",
+  "stoppedAt": "2021-06-15T16:02:24.452Z",
+  "finished": true
+}

--- a/workflows/211.json
+++ b/workflows/211.json
@@ -1,0 +1,162 @@
+{
+  "id": 211,
+  "name": "SSH:Command:execute:File:upload",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "command": "whoami"
+      },
+      "name": "SSH",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [
+        480,
+        140
+      ],
+      "credentials": {
+        "sshPassword": "SSH creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "path": "/home/n/nodeqa/.tmp/",
+        "options": {
+          "fileName": "fixedtestingfilename"
+        }
+      },
+      "name": "SSH1",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [
+        770,
+        310
+      ],
+      "credentials": {
+        "sshPassword": "SSH creds"
+      }
+    },
+    {
+      "parameters": {
+        "values": {
+          "string": [
+            {
+              "name": "name",
+              "value": "={{Date()}}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "name": "Set",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 1,
+      "position": [
+        480,
+        310
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "jsonToBinary",
+        "convertAllData": false,
+        "sourceKey": "name",
+        "options": {
+          "encoding": "utf8",
+          "mimeType": "text"
+        }
+      },
+      "name": "Move Binary Data",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1,
+      "position": [
+        620,
+        310
+      ]
+    },
+    {
+      "parameters": {
+        "resource": "file",
+        "operation": "download",
+        "path": "/home/n/nodeqa/.tmp/fixedtestingfilename"
+      },
+      "name": "SSH2",
+      "type": "n8n-nodes-base.ssh",
+      "typeVersion": 1,
+      "position": [
+        940,
+        310
+      ],
+      "credentials": {
+        "sshPassword": "SSH creds"
+      },
+      "disabled": true
+    }
+  ],
+  "connections": {
+    "SSH1": {
+      "main": [
+        [
+          {
+            "node": "SSH2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set": {
+      "main": [
+        [
+          {
+            "node": "Move Binary Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Move Binary Data": {
+      "main": [
+        [
+          {
+            "node": "SSH1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "SSH",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Set",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-05-31T10:52:06.208Z",
+  "updatedAt": "2021-06-07T09:21:43.338Z",
+  "settings": {},
+  "staticData": null
+}

--- a/workflows/211.json
+++ b/workflows/211.json
@@ -31,7 +31,7 @@
     {
       "parameters": {
         "resource": "file",
-        "path": "/home/n/nodeqa/.tmp/",
+        "path": "/config",
         "options": {
           "fileName": "fixedtestingfilename"
         }
@@ -89,7 +89,7 @@
       "parameters": {
         "resource": "file",
         "operation": "download",
-        "path": "/home/n/nodeqa/.tmp/fixedtestingfilename"
+        "path": "/config/fixedtestingfilename"
       },
       "name": "SSH2",
       "type": "n8n-nodes-base.ssh",
@@ -156,7 +156,7 @@
     }
   },
   "createdAt": "2021-05-31T10:52:06.208Z",
-  "updatedAt": "2021-06-07T09:21:43.338Z",
+  "updatedAt": "2021-07-14T13:07:09.504Z",
   "settings": {},
   "staticData": null
 }


### PR DESCRIPTION
This pr includes a workflow to test the SSH node

Workflow n°211 support:

- Command: execute
- File: upload

Note: the workflow doesn't support `download:File` operation, as I couldn't find a workaround permission problem (even the node use `/tmp` as the target directory for downloading)
