### PR TITLE
Add test workflow for Git node

### DIFF
--- a/snapshots/212-snapshot.json
+++ b/snapshots/212-snapshot.json
@@ -1,0 +1,351 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "Start": [
+          {
+            "startTime": 1623744700100,
+            "executionTime": 1,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {}
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Delete existing dir": [
+          {
+            "startTime": 1623744700101,
+            "executionTime": 7,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "exitCode": 1,
+                      "stderr": "rm: cannot remove '/tmp/nodeQA': No such file or directory",
+                      "stdout": ""
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git": [
+          {
+            "startTime": 1623744700109,
+            "executionTime": 1057,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git1": [
+          {
+            "startTime": 1623744701167,
+            "executionTime": 19,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "_file": ".git/config",
+                      "core.repositoryformatversion": "0",
+                      "core.filemode": "true",
+                      "core.bare": "false",
+                      "core.logallrefupdates": "true",
+                      "remote.origin.url": "https://nodemationqa:SDH%23xDw3E7%3Eb@github.com/nodemationqa/nodeQA",
+                      "remote.origin.fetch": "+refs/heads/*:refs/remotes/origin/*",
+                      "branch.main.remote": "origin",
+                      "branch.main.merge": "refs/heads/main"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git2": [
+          {
+            "startTime": 1623744701187,
+            "executionTime": 19,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git7": [
+          {
+            "startTime": 1623744701207,
+            "executionTime": 14,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Add file to dir": [
+          {
+            "startTime": 1623744701222,
+            "executionTime": 12,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "exitCode": 0,
+                      "stderr": "",
+                      "stdout": ""
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git3": [
+          {
+            "startTime": 1623744701234,
+            "executionTime": 7,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git4": [
+          {
+            "startTime": 1623744701242,
+            "executionTime": 8,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "not_added": [
+                        "json array"
+                      ],
+                      "conflicted": [
+                        "json array"
+                      ],
+                      "created": [
+                        "json array"
+                      ],
+                      "deleted": [
+                        "json array"
+                      ],
+                      "modified": [
+                        "json array"
+                      ],
+                      "renamed": [
+                        "json array"
+                      ],
+                      "files": [
+                        "json array"
+                      ],
+                      "staged": [
+                        "json array"
+                      ],
+                      "ahead": 0,
+                      "behind": 0,
+                      "current": "main",
+                      "tracking": "origin/main"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git5": [
+          {
+            "startTime": 1623744701250,
+            "executionTime": 10,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git6": [
+          {
+            "startTime": 1623744701260,
+            "executionTime": 7,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "hash": "ddbedd3d92ee1ab89ae992ad6a4ac9ba99348ab3",
+                      "date": "2021-06-15T10:11:41+02:00",
+                      "message": "GitNode commit Tue, 15 Jun 2021 08:11:41 GMT",
+                      "refs": "HEAD -> main",
+                      "body": "",
+                      "author_name": "nodemationqa",
+                      "author_email": "nodeqa@n8n.io"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git8": [
+          {
+            "startTime": 1623744701268,
+            "executionTime": 7,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git9": [
+          {
+            "startTime": 1623744701275,
+            "executionTime": 3337,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git10": [
+          {
+            "startTime": 1623744704612,
+            "executionTime": 3177,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git11": [
+          {
+            "startTime": 1623744707790,
+            "executionTime": 456,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git12": [
+          {
+            "startTime": 1623744708247,
+            "executionTime": 436,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Git13": [
+          {
+            "startTime": 1623744708684,
+            "executionTime": 1,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "Git13"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "waitingExecution": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2021-06-15T08:11:40.098Z",
+  "stoppedAt": "2021-06-15T08:11:48.686Z",
+  "finished": true
+}

--- a/workflows/212.json
+++ b/workflows/212.json
@@ -1,0 +1,427 @@
+{
+  "id": 212,
+  "name": "Git:*",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        260,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "authentication": "gitPassword",
+        "operation": "clone",
+        "repositoryPath": "/tmp/nodeQA",
+        "sourceRepository": "https://github.com/nodemationqa/nodeQA"
+      },
+      "name": "Git",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        550,
+        250
+      ],
+      "credentials": {
+        "gitPassword": "Git creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "listConfig",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git1",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        700,
+        250
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "addConfig",
+        "repositoryPath": "/tmp/nodeQA",
+        "key": "user.email",
+        "value": "nodeqa@n8n.io",
+        "options": {
+          "mode": "set"
+        }
+      },
+      "name": "Git2",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        850,
+        250
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "add",
+        "repositoryPath": "/tmp/nodeQA",
+        "pathsToAdd": "/tmp/nodeQA/gitnode_added_file.md"
+      },
+      "name": "Git3",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        550,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "status",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git4",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        700,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "commit",
+        "repositoryPath": "/tmp/nodeQA",
+        "message": "=GitNode commit {{(new Date).toUTCString()}}",
+        "options": {}
+      },
+      "name": "Git5",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        850,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "repositoryPath": "/tmp/nodeQA",
+        "limit": 1,
+        "options": {}
+      },
+      "name": "Git6",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "addConfig",
+        "repositoryPath": "/tmp/nodeQA",
+        "key": "user.name",
+        "value": "nodemationqa",
+        "options": {
+          "mode": "set"
+        }
+      },
+      "name": "Git7",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        250
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "tag",
+        "repositoryPath": "/tmp/nodeQA",
+        "name": "=GitNode-tag-{{Date.now()}}"
+      },
+      "name": "Git8",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        450
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "pushTags",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git9",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        550,
+        650
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "push",
+        "repositoryPath": "/tmp/nodeQA",
+        "options": {}
+      },
+      "name": "Git10",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        700,
+        650
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "pull",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git11",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        850,
+        650
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "fetch",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git12",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        1000,
+        650
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "userSetup",
+        "repositoryPath": "/tmp/nodeQA"
+      },
+      "name": "Git13",
+      "type": "n8n-nodes-base.git",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        650
+      ],
+      "disabled": true
+    },
+    {
+      "parameters": {
+        "command": "rm -r /tmp/nodeQA"
+      },
+      "name": "Delete existing dir",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        400,
+        250
+      ]
+    },
+    {
+      "parameters": {
+        "command": "=echo \"File added to repo at {{(new Date).toUTCString()}} using Git node\" > /tmp/nodeQA/gitnode_added_file.md"
+      },
+      "name": "Add file to dir",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [
+        1150,
+        250
+      ]
+    }
+  ],
+  "connections": {
+    "Git": {
+      "main": [
+        [
+          {
+            "node": "Git1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Delete existing dir",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git1": {
+      "main": [
+        [
+          {
+            "node": "Git2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git2": {
+      "main": [
+        [
+          {
+            "node": "Git7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git3": {
+      "main": [
+        [
+          {
+            "node": "Git4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git4": {
+      "main": [
+        [
+          {
+            "node": "Git5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git5": {
+      "main": [
+        [
+          {
+            "node": "Git6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git7": {
+      "main": [
+        [
+          {
+            "node": "Add file to dir",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git6": {
+      "main": [
+        [
+          {
+            "node": "Git8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git8": {
+      "main": [
+        [
+          {
+            "node": "Git9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git9": {
+      "main": [
+        [
+          {
+            "node": "Git10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git10": {
+      "main": [
+        [
+          {
+            "node": "Git11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git11": {
+      "main": [
+        [
+          {
+            "node": "Git12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Git12": {
+      "main": [
+        [
+          {
+            "node": "Git13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delete existing dir": {
+      "main": [
+        [
+          {
+            "node": "Git",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Add file to dir": {
+      "main": [
+        [
+          {
+            "node": "Git3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-06-01T08:10:39.407Z",
+  "updatedAt": "2021-06-07T09:50:34.256Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Git node

Workflow n°212 support:

- clone
- listConfig
- addConfig
- add
- status
- commit
- log
- tag
- pushTags
- push
- pull
- fetch

Note: the workflow doesn't support `user setup` operation, as it is disabled for now
