### PR TITLE
Add test workflow for Discord node

### DIFF
--- a/snapshots/214-snapshot.json
+++ b/snapshots/214-snapshot.json
@@ -1,0 +1,51 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "Start": [
+          {
+            "startTime": 1623742120279,
+            "executionTime": 0,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {}
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Discord": [
+          {
+            "startTime": 1623742120280,
+            "executionTime": 423,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "success": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "Discord"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "waitingExecution": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2021-06-15T07:28:40.277Z",
+  "stoppedAt": "2021-06-15T07:28:40.704Z",
+  "finished": true
+}

--- a/workflows/214.json
+++ b/workflows/214.json
@@ -1,0 +1,47 @@
+{
+  "id": 214,
+  "name": "Discord:sendMessage",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "webhookUri": "https://discord.com/api/webhooks/853902675845447722/X4lCHHah4k1RNsrt773IzP6MtTGyUGbRaG6_TfqTEtO0acUIvd2iaefsEpGmRwgz1el8",
+        "text": "=Posted At {{(new Date).toUTCString()}}"
+      },
+      "name": "Discord",
+      "type": "n8n-nodes-base.discord",
+      "typeVersion": 1,
+      "position": [
+        490,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-06-03T11:22:25.194Z",
+  "updatedAt": "2021-06-14T07:46:26.827Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Discord node

Workflow n°214 support:

- sendMessage

Note: the node support only one operation for now, we can merge the workflow and updated when Discord PR added by Ivan get merged
