### PR TITLE
Add Copper testing workflow

### DIFF
--- a/snapshots/221-snapshot.json
+++ b/snapshots/221-snapshot.json
@@ -1,0 +1,1235 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "Start": [
+          {
+            "startTime": 1625825077774,
+            "executionTime": 0,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {}
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper": [
+          {
+            "startTime": 1625825077775,
+            "executionTime": 1552,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 54204469,
+                      "name": "Company1625825077776",
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "contact_type_id": {
+                        "object": true
+                      },
+                      "details": "Description",
+                      "email_domain": "test1625825077777",
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "date_created": 1625825079,
+                      "date_modified": 1625825079
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper6": [
+          {
+            "startTime": 1625825079329,
+            "executionTime": 1172,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 120884839,
+                      "name": "Person1625825079330",
+                      "prefix": {
+                        "object": true
+                      },
+                      "first_name": "Person1625825079330",
+                      "middle_name": {
+                        "object": true
+                      },
+                      "last_name": {
+                        "object": true
+                      },
+                      "suffix": {
+                        "object": true
+                      },
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "contact_type_id": 1774299,
+                      "details": "Person description - Test",
+                      "emails": [
+                        "json array"
+                      ],
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "title": {
+                        "object": true
+                      },
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825080,
+                      "date_modified": 1625825080,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "interaction_count": 0,
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper11": [
+          {
+            "startTime": 1625825080502,
+            "executionTime": 1480,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1256548,
+                      "name": "Project1625825080504",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "status": "Open",
+                      "details": "Detail projects - Test",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825081,
+                      "date_modified": 1625825081
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper16": [
+          {
+            "startTime": 1625825081983,
+            "executionTime": 973,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 31327086,
+                      "name": "Task1625825081984",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": 930585,
+                      "due_date": {
+                        "object": true
+                      },
+                      "reminder_date": {
+                        "object": true
+                      },
+                      "completed_date": {
+                        "object": true
+                      },
+                      "priority": "High",
+                      "status": "Open",
+                      "details": "Task description",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825082,
+                      "date_modified": 1625825082,
+                      "custom_activity_type_id": 1154633
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper21": [
+          {
+            "startTime": 1625825082956,
+            "executionTime": 1127,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 930585,
+                      "name": "nodeqagm",
+                      "email": "node8qa@gmail.com"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper1": [
+          {
+            "startTime": 1625825084083,
+            "executionTime": 1108,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 54204469,
+                      "name": "Company1625825077776",
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "contact_type_id": {
+                        "object": true
+                      },
+                      "details": "Description",
+                      "email_domain": "test1625825077777",
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "date_created": 1625825079,
+                      "date_modified": 1625825079
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper5": [
+          {
+            "startTime": 1625825085192,
+            "executionTime": 1138,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1315469,
+                      "name": "Advertising"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper12": [
+          {
+            "startTime": 1625825086331,
+            "executionTime": 1027,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1256548,
+                      "name": "Project1625825080504",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "status": "Open",
+                      "details": "Detail projects - Test",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825081,
+                      "date_modified": 1625825081
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper17": [
+          {
+            "startTime": 1625825087359,
+            "executionTime": 839,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 31327086,
+                      "name": "Task1625825081984",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": 930585,
+                      "due_date": {
+                        "object": true
+                      },
+                      "reminder_date": {
+                        "object": true
+                      },
+                      "completed_date": {
+                        "object": true
+                      },
+                      "priority": "High",
+                      "status": "Open",
+                      "details": "Task description",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825082,
+                      "date_modified": 1625825082,
+                      "custom_activity_type_id": 1154633
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper2": [
+          {
+            "startTime": 1625825088199,
+            "executionTime": 1515,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 54204469,
+                      "name": "UpdatedCompany1625825077776",
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "contact_type_id": {
+                        "object": true
+                      },
+                      "details": "Description",
+                      "email_domain": "test1625825077777",
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "date_created": 1625825079,
+                      "date_modified": 1625825089
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper22": [
+          {
+            "startTime": 1625825089715,
+            "executionTime": 2105,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 24800943,
+                      "name": "Opportunity1625825089716",
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "close_date": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "customer_source_id": 1315469,
+                      "details": {
+                        "object": true
+                      },
+                      "loss_reason_id": {
+                        "object": true
+                      },
+                      "pipeline_id": 855016,
+                      "pipeline_stage_id": 4008674,
+                      "primary_contact_id": 120884839,
+                      "priority": "None",
+                      "status": "Open",
+                      "tags": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "monetary_unit": {
+                        "object": true
+                      },
+                      "monetary_value": {
+                        "object": true
+                      },
+                      "converted_unit": "USD",
+                      "converted_value": {
+                        "object": true
+                      },
+                      "win_probability": 5,
+                      "date_stage_changed": 1625825090,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      },
+                      "date_created": 1625825090,
+                      "date_modified": 1625825090,
+                      "custom_fields": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper13": [
+          {
+            "startTime": 1625825091821,
+            "executionTime": 965,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1256548,
+                      "name": "UpatedProject1625825080504",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "status": "Completed",
+                      "details": "Completed Update",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825081,
+                      "date_modified": 1625825092
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper18": [
+          {
+            "startTime": 1625825092787,
+            "executionTime": 946,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 31327086,
+                      "name": "UpdatedTask1625825081984",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": 930585,
+                      "due_date": {
+                        "object": true
+                      },
+                      "reminder_date": {
+                        "object": true
+                      },
+                      "completed_date": 1625825093,
+                      "priority": "None",
+                      "status": "Completed",
+                      "details": "Update task description",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825082,
+                      "date_modified": 1625825093,
+                      "custom_activity_type_id": 1154633
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper3": [
+          {
+            "startTime": 1625825093734,
+            "executionTime": 779,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 54204469,
+                      "name": "UpdatedCompany1625825077776",
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "contact_type_id": {
+                        "object": true
+                      },
+                      "details": "Description",
+                      "email_domain": "test1625825077777",
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "date_created": 1625825079,
+                      "date_modified": 1625825089
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper23": [
+          {
+            "startTime": 1625825094513,
+            "executionTime": 1073,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 24800943,
+                      "name": "Opportunity1625825089716",
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "close_date": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "customer_source_id": 1315469,
+                      "details": {
+                        "object": true
+                      },
+                      "loss_reason_id": {
+                        "object": true
+                      },
+                      "pipeline_id": 855016,
+                      "pipeline_stage_id": 4008674,
+                      "primary_contact_id": 120884839,
+                      "priority": "None",
+                      "status": "Open",
+                      "tags": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "monetary_unit": {
+                        "object": true
+                      },
+                      "monetary_value": {
+                        "object": true
+                      },
+                      "converted_unit": "USD",
+                      "converted_value": {
+                        "object": true
+                      },
+                      "win_probability": 5,
+                      "date_stage_changed": 1625825090,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      },
+                      "date_created": 1625825090,
+                      "date_modified": 1625825091,
+                      "custom_fields": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper14": [
+          {
+            "startTime": 1625825095586,
+            "executionTime": 876,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1256537,
+                      "name": "Customize Your New CRM",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": 930585,
+                      "status": "Open",
+                      "details": "Visit our settings section to discover all the ways you can customize Copper to fit your sales workflow.",
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625822590,
+                      "date_modified": 1625822591
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper19": [
+          {
+            "startTime": 1625825096462,
+            "executionTime": 912,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 31326818,
+                      "name": "Check out integrations",
+                      "related_resource": {
+                        "object": true
+                      },
+                      "assignee_id": 930585,
+                      "due_date": {
+                        "object": true
+                      },
+                      "reminder_date": {
+                        "object": true
+                      },
+                      "completed_date": {
+                        "object": true
+                      },
+                      "priority": "None",
+                      "status": "Open",
+                      "details": {
+                        "object": true
+                      },
+                      "tags": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625822590,
+                      "date_modified": 1625822590,
+                      "custom_activity_type_id": 1154635
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper4": [
+          {
+            "startTime": 1625825097374,
+            "executionTime": 902,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 54204469,
+                      "is_deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper24": [
+          {
+            "startTime": 1625825098276,
+            "executionTime": 1030,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 24800943,
+                      "name": "UpdatedOpportunity1625825089716",
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "close_date": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "customer_source_id": 1315469,
+                      "details": {
+                        "object": true
+                      },
+                      "loss_reason_id": {
+                        "object": true
+                      },
+                      "pipeline_id": 855016,
+                      "pipeline_stage_id": 4008674,
+                      "primary_contact_id": 120884839,
+                      "priority": "None",
+                      "status": "Open",
+                      "tags": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "monetary_unit": {
+                        "object": true
+                      },
+                      "monetary_value": {
+                        "object": true
+                      },
+                      "converted_unit": "USD",
+                      "converted_value": {
+                        "object": true
+                      },
+                      "win_probability": 5,
+                      "date_stage_changed": 1625825090,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      },
+                      "date_created": 1625825090,
+                      "date_modified": 1625825098,
+                      "custom_fields": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper15": [
+          {
+            "startTime": 1625825099306,
+            "executionTime": 902,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 1256548,
+                      "is_deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper20": [
+          {
+            "startTime": 1625825100209,
+            "executionTime": 918,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 31327086,
+                      "is_deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper25": [
+          {
+            "startTime": 1625825101128,
+            "executionTime": 815,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 24800789,
+                      "name": "25 Office Chairs (Sample - Try me!)",
+                      "assignee_id": 930585,
+                      "close_date": "7/16/2021",
+                      "company_id": 54204386,
+                      "company_name": "Copper",
+                      "customer_source_id": 1315469,
+                      "details": "Opportunities are created for People and Companies that are interested in buying your products or services. Create Opportunities for People and Companies to move them through one of your Pipelines.",
+                      "loss_reason_id": {
+                        "object": true
+                      },
+                      "pipeline_id": 855016,
+                      "pipeline_stage_id": 4008677,
+                      "primary_contact_id": 120884414,
+                      "priority": "None",
+                      "status": "Open",
+                      "tags": [
+                        "json array"
+                      ],
+                      "interaction_count": 0,
+                      "monetary_unit": "USD",
+                      "monetary_value": 75000,
+                      "converted_unit": "USD",
+                      "converted_value": "75000.0",
+                      "win_probability": 40,
+                      "date_stage_changed": 1625822589,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      },
+                      "date_created": 1625822589,
+                      "date_modified": 1625822593,
+                      "custom_fields": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper26": [
+          {
+            "startTime": 1625825101944,
+            "executionTime": 912,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 24800943,
+                      "is_deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper7": [
+          {
+            "startTime": 1625825102857,
+            "executionTime": 678,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 120884839,
+                      "name": "Person1625825079330",
+                      "prefix": {
+                        "object": true
+                      },
+                      "first_name": "Person1625825079330",
+                      "middle_name": {
+                        "object": true
+                      },
+                      "last_name": {
+                        "object": true
+                      },
+                      "suffix": {
+                        "object": true
+                      },
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "contact_type_id": 1774299,
+                      "details": "Person description - Test",
+                      "emails": [
+                        "json array"
+                      ],
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "title": {
+                        "object": true
+                      },
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825080,
+                      "date_modified": 1625825091,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "interaction_count": 0,
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper8": [
+          {
+            "startTime": 1625825103535,
+            "executionTime": 872,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 120884839,
+                      "name": "UpdatedPerson1625825079330",
+                      "prefix": {
+                        "object": true
+                      },
+                      "first_name": "UpdatedPerson1625825079330",
+                      "middle_name": {
+                        "object": true
+                      },
+                      "last_name": {
+                        "object": true
+                      },
+                      "suffix": {
+                        "object": true
+                      },
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "company_id": {
+                        "object": true
+                      },
+                      "company_name": {
+                        "object": true
+                      },
+                      "contact_type_id": 1774299,
+                      "details": "Person description - Test",
+                      "emails": [
+                        "json array"
+                      ],
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "title": {
+                        "object": true
+                      },
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625825080,
+                      "date_modified": 1625825104,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "interaction_count": 0,
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper9": [
+          {
+            "startTime": 1625825104408,
+            "executionTime": 931,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 120884416,
+                      "name": "Brittany Hughes (Sample - Try me!)",
+                      "prefix": {
+                        "object": true
+                      },
+                      "first_name": "Brittany Hughes (Sample - Try me!)",
+                      "middle_name": {
+                        "object": true
+                      },
+                      "last_name": {
+                        "object": true
+                      },
+                      "suffix": {
+                        "object": true
+                      },
+                      "address": {
+                        "object": true
+                      },
+                      "assignee_id": {
+                        "object": true
+                      },
+                      "company_id": 54204386,
+                      "company_name": "Copper",
+                      "contact_type_id": 1774297,
+                      "details": {
+                        "object": true
+                      },
+                      "emails": [
+                        "json array"
+                      ],
+                      "phone_numbers": [
+                        "json array"
+                      ],
+                      "socials": [
+                        "json array"
+                      ],
+                      "tags": [
+                        "json array"
+                      ],
+                      "title": "Lead Product Designer",
+                      "websites": [
+                        "json array"
+                      ],
+                      "custom_fields": [
+                        "json array"
+                      ],
+                      "date_created": 1625822589,
+                      "date_modified": 1625822591,
+                      "date_last_contacted": {
+                        "object": true
+                      },
+                      "interaction_count": 0,
+                      "leads_converted_from": [
+                        "json array"
+                      ],
+                      "date_lead_created": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Copper10": [
+          {
+            "startTime": 1625825105339,
+            "executionTime": 1284,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": 120884839,
+                      "is_deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "Copper10"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "waitingExecution": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2021-07-09T10:04:37.768Z",
+  "stoppedAt": "2021-07-09T10:05:06.624Z",
+  "finished": true
+}

--- a/workflows/221.json
+++ b/workflows/221.json
@@ -1,0 +1,816 @@
+{
+  "id": 221,
+  "name": "Copper:Company:*:Person:*:Opportunity:*:Project:*:Task:*:CustomerSource:getAll:User:getAll",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        250,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "name": "=Company{{Date.now()}}",
+        "additionalFields": {
+          "address": {
+            "addressFields": {
+              "street": "street",
+              "city": "city",
+              "state": "state",
+              "postal_code": "1001",
+              "country": "country"
+            }
+          },
+          "details": "Description ",
+          "email_domain": "=Test{{Date.now()}}",
+          "phone_numbers": {
+            "phoneFields": [
+              {
+                "number": "42424242",
+                "category": "mobile"
+              }
+            ]
+          }
+        }
+      },
+      "name": "Copper",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        500,
+        130
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "companyId": "={{$node[\"Copper\"].json[\"id\"]}}"
+      },
+      "name": "Copper1",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        650,
+        130
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "update",
+        "companyId": "={{$node[\"Copper\"].json[\"id\"]}}",
+        "updateFields": {
+          "address": {
+            "addressFields": {
+              "street": "UpdateStreet",
+              "city": "UpdatedCity",
+              "state": "UpdateState",
+              "postal_code": "1002",
+              "country": "UpdateCountry"
+            }
+          },
+          "name": "=Updated{{$node[\"Copper1\"].json[\"name\"]}}"
+        }
+      },
+      "name": "Copper2",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        800,
+        130
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "getAll",
+        "limit": 1,
+        "filterFields": {
+          "name": "={{$node[\"Copper2\"].json[\"name\"]}}"
+        }
+      },
+      "name": "Copper3",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        950,
+        130
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "operation": "delete",
+        "companyId": "={{$node[\"Copper\"].json[\"id\"]}}"
+      },
+      "name": "Copper4",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        130
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customerSource",
+        "limit": 1
+      },
+      "name": "Copper5",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        650,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "name": "=Person{{Date.now()}}",
+        "additionalFields": {
+          "details": "Person description - Test"
+        }
+      },
+      "name": "Copper6",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        500,
+        290
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "get",
+        "personId": "={{$node[\"Copper6\"].json[\"id\"]}}"
+      },
+      "name": "Copper7",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        750,
+        290
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "update",
+        "personId": "={{$node[\"Copper6\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "=Updated{{$node[\"Copper7\"].json[\"name\"]}}"
+        }
+      },
+      "name": "Copper8",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        900,
+        290
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "getAll",
+        "limit": 1,
+        "filterFields": {}
+      },
+      "name": "Copper9",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1050,
+        290
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "person",
+        "operation": "delete",
+        "personId": "={{$node[\"Copper6\"].json[\"id\"]}}"
+      },
+      "name": "Copper10",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1200,
+        290
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "project",
+        "name": "=Project{{Date.now()}}",
+        "additionalFields": {
+          "details": "Detail projects - Test",
+          "status": "Open"
+        }
+      },
+      "name": "Copper11",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        500,
+        590
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "project",
+        "operation": "get",
+        "projectId": "={{$node[\"Copper11\"].json[\"id\"]}}"
+      },
+      "name": "Copper12",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        650,
+        590
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "project",
+        "operation": "update",
+        "projectId": "={{$node[\"Copper11\"].json[\"id\"]}}",
+        "updateFields": {
+          "details": "Completed Update",
+          "name": "=Upated{{$node[\"Copper12\"].json[\"name\"]}}",
+          "status": "Completed"
+        }
+      },
+      "name": "Copper13",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        800,
+        590
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "project",
+        "operation": "getAll",
+        "limit": 1,
+        "filterFields": {}
+      },
+      "name": "Copper14",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        950,
+        590
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "project",
+        "operation": "delete",
+        "projectId": "={{$node[\"Copper11\"].json[\"id\"]}}"
+      },
+      "name": "Copper15",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        590
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "name": "=Task{{Date.now()}}",
+        "additionalFields": {
+          "details": "Task description",
+          "priority": "High",
+          "status": "Open"
+        }
+      },
+      "name": "Copper16",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        500,
+        740
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "get",
+        "taskId": "={{$node[\"Copper16\"].json[\"id\"]}}"
+      },
+      "name": "Copper17",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        650,
+        740
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "update",
+        "taskId": "={{$node[\"Copper16\"].json[\"id\"]}}",
+        "updateFields": {
+          "details": "Update task description",
+          "name": "=Updated{{$node[\"Copper17\"].json[\"name\"]}}",
+          "priority": "None",
+          "status": "Completed"
+        }
+      },
+      "name": "Copper18",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        800,
+        740
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "getAll",
+        "limit": 1,
+        "filterFields": {
+          "project_ids": "={{$node[\"Copper18\"].json[\"id\"]}},"
+        }
+      },
+      "name": "Copper19",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        950,
+        740
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "task",
+        "operation": "delete",
+        "taskId": "={{$node[\"Copper16\"].json[\"id\"]}}"
+      },
+      "name": "Copper20",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        740
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "user",
+        "limit": 1
+      },
+      "name": "Copper21",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        500,
+        -10
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "name": "=Opportunity{{Date.now()}}",
+        "customerSourceId": "={{$node[\"Copper5\"].json[\"id\"]}}",
+        "primaryContactId": "={{$node[\"Copper6\"].json[\"id\"]}}"
+      },
+      "name": "Copper22",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        800,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "get",
+        "opportunityId": "={{$node[\"Copper22\"].json[\"id\"]}}"
+      },
+      "name": "Copper23",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        950,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "update",
+        "opportunityId": "={{$node[\"Copper22\"].json[\"id\"]}}",
+        "updateFields": {
+          "name": "=Updated{{$node[\"Copper23\"].json[\"name\"]}}"
+        }
+      },
+      "name": "Copper24",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1100,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "getAll",
+        "limit": 1,
+        "filterFields": {}
+      },
+      "name": "Copper25",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1250,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "opportunity",
+        "operation": "delete",
+        "opportunityId": "={{$node[\"Copper22\"].json[\"id\"]}}"
+      },
+      "name": "Copper26",
+      "type": "n8n-nodes-base.copper",
+      "typeVersion": 1,
+      "position": [
+        1400,
+        440
+      ],
+      "credentials": {
+        "copperApi": "Copper API creds"
+      }
+    }
+  ],
+  "connections": {
+    "Copper": {
+      "main": [
+        [
+          {
+            "node": "Copper1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper1": {
+      "main": [
+        [
+          {
+            "node": "Copper2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper2": {
+      "main": [
+        [
+          {
+            "node": "Copper3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper3": {
+      "main": [
+        [
+          {
+            "node": "Copper4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper6": {
+      "main": [
+        [
+          {
+            "node": "Copper5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper7": {
+      "main": [
+        [
+          {
+            "node": "Copper8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper8": {
+      "main": [
+        [
+          {
+            "node": "Copper9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper9": {
+      "main": [
+        [
+          {
+            "node": "Copper10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper11": {
+      "main": [
+        [
+          {
+            "node": "Copper12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper12": {
+      "main": [
+        [
+          {
+            "node": "Copper13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper13": {
+      "main": [
+        [
+          {
+            "node": "Copper14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper14": {
+      "main": [
+        [
+          {
+            "node": "Copper15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper16": {
+      "main": [
+        [
+          {
+            "node": "Copper17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper17": {
+      "main": [
+        [
+          {
+            "node": "Copper18",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper18": {
+      "main": [
+        [
+          {
+            "node": "Copper19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper19": {
+      "main": [
+        [
+          {
+            "node": "Copper20",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Copper",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Copper6",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Copper11",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Copper16",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Copper21",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper5": {
+      "main": [
+        [
+          {
+            "node": "Copper22",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper22": {
+      "main": [
+        [
+          {
+            "node": "Copper23",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper23": {
+      "main": [
+        [
+          {
+            "node": "Copper24",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper24": {
+      "main": [
+        [
+          {
+            "node": "Copper25",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper25": {
+      "main": [
+        [
+          {
+            "node": "Copper26",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Copper26": {
+      "main": [
+        [
+          {
+            "node": "Copper7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-06-25T10:58:54.559Z",
+  "updatedAt": "2021-07-09T10:01:28.338Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Copper node

Workflow n°221 support:

- Company: create get update getAll delete
- Person: create get update getAll delete
- Opportunity: create get update getAll delete
- Project: create get update getAll delete
- Task: create get update getAll delete
- CustomerSource: getAll
- User: getAll

Note: the workflow doesn't support `lead` operation because of the plan limitation. 