### PR TITLE
Add test workflow for Stripe node

### DIFF
--- a/snapshots/230-snapshot.json
+++ b/snapshots/230-snapshot.json
@@ -1,0 +1,1007 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "Start": [
+          {
+            "startTime": 1626451246707,
+            "executionTime": 0,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {}
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe": [
+          {
+            "startTime": 1626451246708,
+            "executionTime": 711,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "object": "balance",
+                      "available": [
+                        "json array"
+                      ],
+                      "livemode": false,
+                      "pending": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe15": [
+          {
+            "startTime": 1626451247420,
+            "executionTime": 534,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "ch_1JDrnNH0zmR2qems6A1z0rKI",
+                      "object": "charge",
+                      "amount": 100,
+                      "amount_captured": 0,
+                      "amount_refunded": 0,
+                      "application": {
+                        "object": true
+                      },
+                      "application_fee": {
+                        "object": true
+                      },
+                      "application_fee_amount": {
+                        "object": true
+                      },
+                      "balance_transaction": {
+                        "object": true
+                      },
+                      "billing_details": {
+                        "object": true
+                      },
+                      "calculated_statement_descriptor": {
+                        "object": true
+                      },
+                      "captured": false,
+                      "created": 1626444821,
+                      "currency": "eur",
+                      "customer": {
+                        "object": true
+                      },
+                      "description": "Update Description Fri Jul 16 2021 17:58:08 GMT+0200 (Central European Summer Time)",
+                      "destination": {
+                        "object": true
+                      },
+                      "dispute": {
+                        "object": true
+                      },
+                      "disputed": false,
+                      "failure_code": {
+                        "object": true
+                      },
+                      "failure_message": {
+                        "object": true
+                      },
+                      "fraud_details": {
+                        "object": true
+                      },
+                      "invoice": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "on_behalf_of": {
+                        "object": true
+                      },
+                      "order": {
+                        "object": true
+                      },
+                      "outcome": {
+                        "object": true
+                      },
+                      "paid": true,
+                      "payment_intent": {
+                        "object": true
+                      },
+                      "payment_method": "card_1JDrnNH0zmR2qemscQuvNopV",
+                      "payment_method_details": {
+                        "object": true
+                      },
+                      "receipt_email": {
+                        "object": true
+                      },
+                      "receipt_number": {
+                        "object": true
+                      },
+                      "receipt_url": "https://pay.stripe.com/receipts/acct_1JDrf6H0zmR2qems/ch_1JDrnNH0zmR2qems6A1z0rKI/rcpt_JrazgrUXYc0NnGAhkPPbJj0GHg3Nc7i",
+                      "refunded": false,
+                      "refunds": {
+                        "object": true
+                      },
+                      "review": {
+                        "object": true
+                      },
+                      "shipping": {
+                        "object": true
+                      },
+                      "source": {
+                        "object": true
+                      },
+                      "source_transfer": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "statement_descriptor_suffix": {
+                        "object": true
+                      },
+                      "status": "succeeded",
+                      "transfer_data": {
+                        "object": true
+                      },
+                      "transfer_group": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe1": [
+          {
+            "startTime": 1626451247956,
+            "executionTime": 566,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "cus_JrciDP4sQjZGLS",
+                      "object": "customer",
+                      "address": {
+                        "object": true
+                      },
+                      "balance": 0,
+                      "created": 1626451248,
+                      "currency": {
+                        "object": true
+                      },
+                      "default_source": {
+                        "object": true
+                      },
+                      "delinquent": false,
+                      "description": "Customer descr",
+                      "discount": {
+                        "object": true
+                      },
+                      "email": "customer1626451247964@fakeemail.com",
+                      "invoice_prefix": "AC6EFEEE",
+                      "invoice_settings": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": "CustomerName1626451247963",
+                      "phone": "22 333 444",
+                      "preferred_locales": [
+                        "json array"
+                      ],
+                      "shipping": {
+                        "object": true
+                      },
+                      "tax_exempt": "none"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe17": [
+          {
+            "startTime": 1626451248523,
+            "executionTime": 566,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "ch_1JDrnNH0zmR2qems6A1z0rKI",
+                      "object": "charge",
+                      "amount": 100,
+                      "amount_captured": 0,
+                      "amount_refunded": 0,
+                      "application": {
+                        "object": true
+                      },
+                      "application_fee": {
+                        "object": true
+                      },
+                      "application_fee_amount": {
+                        "object": true
+                      },
+                      "balance_transaction": {
+                        "object": true
+                      },
+                      "billing_details": {
+                        "object": true
+                      },
+                      "calculated_statement_descriptor": {
+                        "object": true
+                      },
+                      "captured": false,
+                      "created": 1626444821,
+                      "currency": "eur",
+                      "customer": {
+                        "object": true
+                      },
+                      "description": "Update Description Fri Jul 16 2021 17:58:08 GMT+0200 (Central European Summer Time)",
+                      "destination": {
+                        "object": true
+                      },
+                      "dispute": {
+                        "object": true
+                      },
+                      "disputed": false,
+                      "failure_code": {
+                        "object": true
+                      },
+                      "failure_message": {
+                        "object": true
+                      },
+                      "fraud_details": {
+                        "object": true
+                      },
+                      "invoice": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "on_behalf_of": {
+                        "object": true
+                      },
+                      "order": {
+                        "object": true
+                      },
+                      "outcome": {
+                        "object": true
+                      },
+                      "paid": true,
+                      "payment_intent": {
+                        "object": true
+                      },
+                      "payment_method": "card_1JDrnNH0zmR2qemscQuvNopV",
+                      "payment_method_details": {
+                        "object": true
+                      },
+                      "receipt_email": {
+                        "object": true
+                      },
+                      "receipt_number": {
+                        "object": true
+                      },
+                      "receipt_url": "https://pay.stripe.com/receipts/acct_1JDrf6H0zmR2qems/ch_1JDrnNH0zmR2qems6A1z0rKI/rcpt_JrazgrUXYc0NnGAhkPPbJj0GHg3Nc7i",
+                      "refunded": false,
+                      "refunds": {
+                        "object": true
+                      },
+                      "review": {
+                        "object": true
+                      },
+                      "shipping": {
+                        "object": true
+                      },
+                      "source": {
+                        "object": true
+                      },
+                      "source_transfer": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "statement_descriptor_suffix": {
+                        "object": true
+                      },
+                      "status": "succeeded",
+                      "transfer_data": {
+                        "object": true
+                      },
+                      "transfer_group": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe2": [
+          {
+            "startTime": 1626451249090,
+            "executionTime": 517,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "cus_JrciDP4sQjZGLS",
+                      "object": "customer",
+                      "address": {
+                        "object": true
+                      },
+                      "balance": 0,
+                      "created": 1626451248,
+                      "currency": {
+                        "object": true
+                      },
+                      "default_source": {
+                        "object": true
+                      },
+                      "delinquent": false,
+                      "description": "Customer descr",
+                      "discount": {
+                        "object": true
+                      },
+                      "email": "customer1626451247964@fakeemail.com",
+                      "invoice_prefix": "AC6EFEEE",
+                      "invoice_settings": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": "CustomerName1626451247963",
+                      "phone": "22 333 444",
+                      "preferred_locales": [
+                        "json array"
+                      ],
+                      "shipping": {
+                        "object": true
+                      },
+                      "tax_exempt": "none"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe19": [
+          {
+            "startTime": 1626451249608,
+            "executionTime": 728,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "ch_1JDrnNH0zmR2qems6A1z0rKI",
+                      "object": "charge",
+                      "amount": 100,
+                      "amount_captured": 0,
+                      "amount_refunded": 0,
+                      "application": {
+                        "object": true
+                      },
+                      "application_fee": {
+                        "object": true
+                      },
+                      "application_fee_amount": {
+                        "object": true
+                      },
+                      "balance_transaction": {
+                        "object": true
+                      },
+                      "billing_details": {
+                        "object": true
+                      },
+                      "calculated_statement_descriptor": {
+                        "object": true
+                      },
+                      "captured": false,
+                      "created": 1626444821,
+                      "currency": "eur",
+                      "customer": {
+                        "object": true
+                      },
+                      "description": "Update Description Fri Jul 16 2021 18:00:49 GMT+0200 (Central European Summer Time)",
+                      "destination": {
+                        "object": true
+                      },
+                      "dispute": {
+                        "object": true
+                      },
+                      "disputed": false,
+                      "failure_code": {
+                        "object": true
+                      },
+                      "failure_message": {
+                        "object": true
+                      },
+                      "fraud_details": {
+                        "object": true
+                      },
+                      "invoice": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "on_behalf_of": {
+                        "object": true
+                      },
+                      "order": {
+                        "object": true
+                      },
+                      "outcome": {
+                        "object": true
+                      },
+                      "paid": true,
+                      "payment_intent": {
+                        "object": true
+                      },
+                      "payment_method": "card_1JDrnNH0zmR2qemscQuvNopV",
+                      "payment_method_details": {
+                        "object": true
+                      },
+                      "receipt_email": {
+                        "object": true
+                      },
+                      "receipt_number": {
+                        "object": true
+                      },
+                      "receipt_url": "https://pay.stripe.com/receipts/acct_1JDrf6H0zmR2qems/ch_1JDrnNH0zmR2qems6A1z0rKI/rcpt_JrazgrUXYc0NnGAhkPPbJj0GHg3Nc7i",
+                      "refunded": false,
+                      "refunds": {
+                        "object": true
+                      },
+                      "review": {
+                        "object": true
+                      },
+                      "shipping": {
+                        "object": true
+                      },
+                      "source": {
+                        "object": true
+                      },
+                      "source_transfer": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "statement_descriptor_suffix": {
+                        "object": true
+                      },
+                      "status": "succeeded",
+                      "transfer_data": {
+                        "object": true
+                      },
+                      "transfer_group": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe3": [
+          {
+            "startTime": 1626451250337,
+            "executionTime": 556,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "cus_JrciDP4sQjZGLS",
+                      "object": "customer",
+                      "address": {
+                        "object": true
+                      },
+                      "balance": 0,
+                      "created": 1626451248,
+                      "currency": {
+                        "object": true
+                      },
+                      "default_source": {
+                        "object": true
+                      },
+                      "delinquent": false,
+                      "description": "Updated descr",
+                      "discount": {
+                        "object": true
+                      },
+                      "email": "customer1626451247964@fakeemail.com",
+                      "invoice_prefix": "AC6EFEEE",
+                      "invoice_settings": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": "UpdatedCustomerName1626451247963",
+                      "phone": "22 333 444",
+                      "preferred_locales": [
+                        "json array"
+                      ],
+                      "shipping": {
+                        "object": true
+                      },
+                      "tax_exempt": "none"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe4": [
+          {
+            "startTime": 1626451250895,
+            "executionTime": 508,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "cus_JrciDP4sQjZGLS",
+                      "object": "customer",
+                      "address": {
+                        "object": true
+                      },
+                      "balance": 0,
+                      "created": 1626451248,
+                      "currency": {
+                        "object": true
+                      },
+                      "default_source": {
+                        "object": true
+                      },
+                      "delinquent": false,
+                      "description": "Updated descr",
+                      "discount": {
+                        "object": true
+                      },
+                      "email": "customer1626451247964@fakeemail.com",
+                      "invoice_prefix": "AC6EFEEE",
+                      "invoice_settings": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": "UpdatedCustomerName1626451247963",
+                      "phone": "22 333 444",
+                      "preferred_locales": [
+                        "json array"
+                      ],
+                      "shipping": {
+                        "object": true
+                      },
+                      "tax_exempt": "none"
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe6": [
+          {
+            "startTime": 1626451251403,
+            "executionTime": 1202,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "src_1JDtT5H0zmR2qemsLaIcQQxc",
+                      "object": "source",
+                      "amount": 8,
+                      "client_secret": "src_client_secret_NZVxqQmcB3q5Fkg2kSGNkwGT",
+                      "created": 1626451251,
+                      "currency": "eur",
+                      "flow": "none",
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "owner": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "status": "pending",
+                      "type": "wechat",
+                      "usage": "single_use",
+                      "wechat": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe7": [
+          {
+            "startTime": 1626451252605,
+            "executionTime": 612,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "src_1JDtT5H0zmR2qemsLaIcQQxc",
+                      "object": "source",
+                      "amount": 8,
+                      "client_secret": "src_client_secret_NZVxqQmcB3q5Fkg2kSGNkwGT",
+                      "created": 1626451251,
+                      "currency": "eur",
+                      "customer": "cus_JrciDP4sQjZGLS",
+                      "flow": "none",
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "owner": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "status": "pending",
+                      "type": "wechat",
+                      "usage": "single_use",
+                      "wechat": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe9": [
+          {
+            "startTime": 1626451253218,
+            "executionTime": 520,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "e5JcVqBT",
+                      "object": "coupon",
+                      "amount_off": {
+                        "object": true
+                      },
+                      "created": 1626451253,
+                      "currency": {
+                        "object": true
+                      },
+                      "duration": "once",
+                      "duration_in_months": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "max_redemptions": {
+                        "object": true
+                      },
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": {
+                        "object": true
+                      },
+                      "percent_off": 8,
+                      "redeem_by": {
+                        "object": true
+                      },
+                      "times_redeemed": 0,
+                      "valid": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe10": [
+          {
+            "startTime": 1626451253739,
+            "executionTime": 486,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "e5JcVqBT",
+                      "object": "coupon",
+                      "amount_off": {
+                        "object": true
+                      },
+                      "created": 1626451253,
+                      "currency": {
+                        "object": true
+                      },
+                      "duration": "once",
+                      "duration_in_months": {
+                        "object": true
+                      },
+                      "livemode": false,
+                      "max_redemptions": {
+                        "object": true
+                      },
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": {
+                        "object": true
+                      },
+                      "percent_off": 8,
+                      "redeem_by": {
+                        "object": true
+                      },
+                      "times_redeemed": 0,
+                      "valid": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe11": [
+          {
+            "startTime": 1626451254226,
+            "executionTime": 718,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "tok_1JDtT8H0zmR2qemspLNxiNjs",
+                      "object": "token",
+                      "card": {
+                        "object": true
+                      },
+                      "client_ip": "41.62.201.76",
+                      "created": 1626451254,
+                      "livemode": false,
+                      "type": "card",
+                      "used": false
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe12": [
+          {
+            "startTime": 1626451254945,
+            "executionTime": 1128,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "card_1JDtT8H0zmR2qemsdz9VXhJl",
+                      "object": "card",
+                      "address_city": {
+                        "object": true
+                      },
+                      "address_country": {
+                        "object": true
+                      },
+                      "address_line1": {
+                        "object": true
+                      },
+                      "address_line1_check": {
+                        "object": true
+                      },
+                      "address_line2": {
+                        "object": true
+                      },
+                      "address_state": {
+                        "object": true
+                      },
+                      "address_zip": {
+                        "object": true
+                      },
+                      "address_zip_check": {
+                        "object": true
+                      },
+                      "brand": "Visa",
+                      "country": "US",
+                      "customer": "cus_JrciDP4sQjZGLS",
+                      "cvc_check": "pass",
+                      "dynamic_last4": {
+                        "object": true
+                      },
+                      "exp_month": 12,
+                      "exp_year": 2025,
+                      "fingerprint": "UI5PDiK29Z5h4XFj",
+                      "funding": "credit",
+                      "last4": "4242",
+                      "metadata": {
+                        "object": true
+                      },
+                      "name": {
+                        "object": true
+                      },
+                      "tokenization_method": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe13": [
+          {
+            "startTime": 1626451256074,
+            "executionTime": 462,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "src_1JDtT5H0zmR2qemsLaIcQQxc",
+                      "object": "source",
+                      "amount": 8,
+                      "client_secret": "src_client_secret_NZVxqQmcB3q5Fkg2kSGNkwGT",
+                      "created": 1626451251,
+                      "currency": "eur",
+                      "customer": "cus_JrciDP4sQjZGLS",
+                      "flow": "none",
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "owner": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "status": "pending",
+                      "type": "wechat",
+                      "usage": "single_use",
+                      "wechat": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe14": [
+          {
+            "startTime": 1626451256538,
+            "executionTime": 769,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "card_1JDtT8H0zmR2qemsdz9VXhJl",
+                      "object": "card",
+                      "deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe8": [
+          {
+            "startTime": 1626451257308,
+            "executionTime": 651,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "src_1JDtT5H0zmR2qemsLaIcQQxc",
+                      "object": "source",
+                      "amount": 8,
+                      "client_secret": "src_client_secret_NZVxqQmcB3q5Fkg2kSGNkwGT",
+                      "created": 1626451251,
+                      "currency": "eur",
+                      "flow": "none",
+                      "livemode": false,
+                      "metadata": {
+                        "object": true
+                      },
+                      "owner": {
+                        "object": true
+                      },
+                      "statement_descriptor": {
+                        "object": true
+                      },
+                      "status": "canceled",
+                      "type": "wechat",
+                      "usage": "single_use",
+                      "wechat": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Stripe5": [
+          {
+            "startTime": 1626451257960,
+            "executionTime": 525,
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "id": "cus_JrciDP4sQjZGLS",
+                      "object": "customer",
+                      "deleted": true
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "Stripe5"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "waitingExecution": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2021-07-16T16:00:46.702Z",
+  "stoppedAt": "2021-07-16T16:00:58.487Z",
+  "finished": true
+}

--- a/workflows/230.json
+++ b/workflows/230.json
@@ -1,0 +1,547 @@
+{
+  "id": 230,
+  "name": "Stripe:Balance:*:Customer:*:Source:*:Coupon:*:Token:*:CustomerCard:*:Charge:get getAll update",
+  "active": false,
+  "nodes": [
+    {
+      "parameters": {},
+      "name": "Start",
+      "type": "n8n-nodes-base.start",
+      "typeVersion": 1,
+      "position": [
+        270,
+        300
+      ]
+    },
+    {
+      "parameters": {},
+      "name": "Stripe",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        500,
+        300
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customer",
+        "operation": "create",
+        "name": "=CustomerName{{Date.now()}}",
+        "additionalFields": {
+          "description": "Customer descr",
+          "email": "=customer{{Date.now()}}@fakeemail.com",
+          "phone": "=22 333 444"
+        },
+        "type": "wechat"
+      },
+      "name": "Stripe1",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        650,
+        350
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customer",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "type": "wechat"
+      },
+      "name": "Stripe2",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        800,
+        350
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customer",
+        "operation": "update",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "updateFields": {
+          "description": "Updated descr",
+          "name": "=Updated{{$node[\"Stripe1\"].json[\"name\"]}}"
+        },
+        "type": "wechat"
+      },
+      "name": "Stripe3",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        950,
+        350
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customer",
+        "operation": "getAll",
+        "limit": 1,
+        "filters": {},
+        "type": "wechat"
+      },
+      "name": "Stripe4",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1110,
+        350
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customer",
+        "operation": "delete",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "type": "wechat"
+      },
+      "name": "Stripe5",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1910,
+        350
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "source",
+        "operation": "create",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "amount": 8,
+        "currency": "eur",
+        "additionalFields": {},
+        "type": "wechat"
+      },
+      "name": "Stripe6",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        960,
+        500
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "source",
+        "sourceId": "={{$node[\"Stripe6\"].json[\"id\"]}}",
+        "type": "wechat"
+      },
+      "name": "Stripe7",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1110,
+        500
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "coupon",
+        "percentOff": 8,
+        "type": "percent"
+      },
+      "name": "Stripe9",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1310,
+        250
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "coupon",
+        "operation": "getAll",
+        "limit": 1,
+        "type": "percent"
+      },
+      "name": "Stripe10",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1460,
+        250
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "token",
+        "number": "4242424242424242",
+        "cvc": "314",
+        "expirationMonth": "12",
+        "expirationYear": "2025"
+      },
+      "name": "Stripe11",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1310,
+        400
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customerCard",
+        "operation": "add",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "token": "={{$node[\"Stripe11\"].json[\"id\"]}}"
+      },
+      "name": "Stripe12",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1310,
+        550
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customerCard",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "sourceId": "={{$node[\"Stripe6\"].json[\"id\"]}}"
+      },
+      "name": "Stripe13",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1470,
+        550
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "customerCard",
+        "operation": "remove",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "cardId": "={{$node[\"Stripe12\"].json[\"id\"]}}"
+      },
+      "name": "Stripe14",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1620,
+        550
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "charge",
+        "operation": "getAll",
+        "limit": 1,
+        "type": "wechat"
+      },
+      "name": "Stripe15",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        500,
+        150
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "charge",
+        "chargeId": "={{$node[\"Stripe15\"].json[\"id\"]}}",
+        "type": "wechat"
+      },
+      "name": "Stripe17",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        650,
+        150
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "charge",
+        "operation": "update",
+        "chargeId": "={{$node[\"Stripe15\"].json[\"id\"]}}",
+        "updateFields": {
+          "description": "=Update Description {{(new Date()).toString()}}"
+        },
+        "type": "wechat"
+      },
+      "name": "Stripe19",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        800,
+        150
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    },
+    {
+      "parameters": {
+        "resource": "source",
+        "operation": "delete",
+        "customerId": "={{$node[\"Stripe1\"].json[\"id\"]}}",
+        "sourceId": "={{$node[\"Stripe6\"].json[\"id\"]}}",
+        "type": "wechat"
+      },
+      "name": "Stripe8",
+      "type": "n8n-nodes-base.stripe",
+      "typeVersion": 1,
+      "position": [
+        1760,
+        500
+      ],
+      "credentials": {
+        "stripeApi": "Stripe API Test creds"
+      }
+    }
+  ],
+  "connections": {
+    "Start": {
+      "main": [
+        [
+          {
+            "node": "Stripe",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Stripe15",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe": {
+      "main": [
+        [
+          {
+            "node": "Stripe1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe1": {
+      "main": [
+        [
+          {
+            "node": "Stripe2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe2": {
+      "main": [
+        [
+          {
+            "node": "Stripe3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe3": {
+      "main": [
+        [
+          {
+            "node": "Stripe4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe4": {
+      "main": [
+        [
+          {
+            "node": "Stripe6",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe6": {
+      "main": [
+        [
+          {
+            "node": "Stripe7",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe7": {
+      "main": [
+        [
+          {
+            "node": "Stripe9",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe9": {
+      "main": [
+        [
+          {
+            "node": "Stripe10",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe10": {
+      "main": [
+        [
+          {
+            "node": "Stripe11",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe11": {
+      "main": [
+        [
+          {
+            "node": "Stripe12",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe12": {
+      "main": [
+        [
+          {
+            "node": "Stripe13",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe13": {
+      "main": [
+        [
+          {
+            "node": "Stripe14",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe14": {
+      "main": [
+        [
+          {
+            "node": "Stripe8",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe15": {
+      "main": [
+        [
+          {
+            "node": "Stripe17",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe17": {
+      "main": [
+        [
+          {
+            "node": "Stripe19",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Stripe8": {
+      "main": [
+        [
+          {
+            "node": "Stripe5",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "createdAt": "2021-07-16T13:47:43.034Z",
+  "updatedAt": "2021-07-16T16:00:22.935Z",
+  "settings": {},
+  "staticData": null
+}


### PR DESCRIPTION
This pr includes a workflow to test the Stripe node

Workflow n°230 support:

- Balance: get
- Customer: create get update getAll delete
- Source: create get delete
- Coupon: create getAll
- Token: create
- CustomerCard: add get remove
- Charge: get getAll update

Note: this workflow doesn't test the `create:Charge` operation, due to problem when creating a chargeable resource