### PR TITLE
Add tests for LLM sub-node errors

### DIFF
--- a/snapshots/255-snapshot.json
+++ b/snapshots/255-snapshot.json
@@ -1,0 +1,173 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "When clicking ‘Test workflow’": [
+          {
+            "hints": [],
+            "startTime": 1730909041782,
+            "executionTime": 0,
+            "source": [],
+            "executionStatus": "success",
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {},
+                    "pairedItem": {
+                      "item": 0
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "OpenAI Chat Model": [
+          {
+            "startTime": 1730909042295,
+            "executionTime": 207,
+            "executionStatus": "error",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "json array"
+                      ],
+                      "estimatedTokens": 3,
+                      "options": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "json array"
+                      ],
+                      "estimatedTokens": 3,
+                      "options": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "error": {
+              "message": "The resource you are requesting could not be found",
+              "timestamp": 1730909042502,
+              "name": "NodeApiError",
+              "description": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+              "context": {},
+              "cause": {
+                "status": 404,
+                "headers": {
+                  "alt-svc": "h3=\":443\"; ma=86400",
+                  "cf-cache-status": "DYNAMIC",
+                  "cf-ray": "8de6512adc5fe512-TXL",
+                  "connection": "keep-alive",
+                  "content-encoding": "gzip",
+                  "content-type": "application/json; charset=utf-8",
+                  "date": "Wed, 06 Nov 2024 16:04:02 GMT",
+                  "server": "cloudflare",
+                  "set-cookie": "__cf_bm=WNJEeCqEoPzVvQM23bn0dPtxFBJSGW3hlgy4fLTDjCA-1730909042-1.0.1.1-IKh2SSXY9K4GymDmuwu2QNFMhLeKaqXRe0oqBawnz1C8gAD2rSdsBb2hfiCkQicPh_YAXgNF1yLI88mE2MGT1Q; path=/; expires=Wed, 06-Nov-24 16:34:02 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=RyITTkz.YgSfTVhf.ozP_WRkXK498AWz0YptGzGWAb4-1730909042530-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+                  "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+                  "transfer-encoding": "chunked",
+                  "vary": "Origin",
+                  "x-content-type-options": "nosniff",
+                  "x-request-id": "req_e571eb81a626398a898ea38cb1f842e0"
+                },
+                "request_id": "req_e571eb81a626398a898ea38cb1f842e0",
+                "error": {
+                  "message": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+                  "type": "invalid_request_error",
+                  "param": null,
+                  "code": "model_not_found"
+                },
+                "code": "model_not_found",
+                "param": null,
+                "type": "invalid_request_error",
+                "lc_error_code": "MODEL_NOT_FOUND",
+                "attemptNumber": 1,
+                "retriesLeft": 2
+              }
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "OpenAI Chat Model",
+                  "runIndex": 0
+                }
+              ]
+            }
+          }
+        ],
+        "Basic LLM Chain": [
+          {
+            "hints": [],
+            "startTime": 1730909041783,
+            "executionTime": 720,
+            "source": [
+              {
+                "previousNode": "When clicking ‘Test workflow’"
+              }
+            ],
+            "executionStatus": "success",
+            "data": {
+              "main": [
+                [],
+                [
+                  {
+                    "json": {
+                      "error": "The resource you are requesting could not be found"
+                    },
+                    "pairedItem": {
+                      "item": 0
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "Basic LLM Chain"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "metadata": {
+        "OpenAI Chat Model": [
+          {
+            "subRun": [
+              {
+                "node": "OpenAI Chat Model",
+                "runIndex": 0
+              }
+            ]
+          }
+        ]
+      },
+      "waitingExecution": {},
+      "waitingExecutionSource": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2024-11-06T16:04:01.781Z",
+  "stoppedAt": "2024-11-06T16:04:02.503Z",
+  "status": "running",
+  "finished": true
+}

--- a/snapshots/256-snapshot.json
+++ b/snapshots/256-snapshot.json
@@ -1,0 +1,505 @@
+{
+  "data": {
+    "startData": {},
+    "resultData": {
+      "runData": {
+        "When clicking ‘Test workflow’": [
+          {
+            "hints": [],
+            "startTime": 1730909642644,
+            "executionTime": 0,
+            "source": [],
+            "executionStatus": "success",
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {},
+                    "pairedItem": {
+                      "item": 0
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "OpenAI Chat Model": [
+          {
+            "startTime": 1730909643144,
+            "executionTime": 1085,
+            "executionStatus": "success",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "response": {
+                        "object": true
+                      },
+                      "tokenUsage": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "System: You are a helpful assistant\nHuman: What happened yesterday?"
+                      ],
+                      "estimatedTokens": 14,
+                      "options": {
+                        "openai_api_key": {
+                          "lc": 1,
+                          "type": "secret",
+                          "id": [
+                            "OPENAI_API_KEY"
+                          ]
+                        },
+                        "model": "gpt-4o-mini",
+                        "timeout": 60000,
+                        "max_retries": 2,
+                        "configuration": {},
+                        "model_kwargs": {}
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "OpenAI Chat Model",
+                  "runIndex": 0
+                },
+                {
+                  "node": "OpenAI Chat Model",
+                  "runIndex": 1
+                }
+              ]
+            }
+          },
+          {
+            "startTime": 1730909645189,
+            "executionTime": 883,
+            "executionStatus": "success",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "response": {
+                        "object": true
+                      },
+                      "tokenUsage": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "System: You are a helpful assistant\nHuman: What happened yesterday?\nAI: \nTool: "
+                      ],
+                      "estimatedTokens": 20,
+                      "options": {
+                        "openai_api_key": {
+                          "lc": 1,
+                          "type": "secret",
+                          "id": [
+                            "OPENAI_API_KEY"
+                          ]
+                        },
+                        "model": "gpt-4o-mini",
+                        "timeout": 60000,
+                        "max_retries": 2,
+                        "configuration": {},
+                        "model_kwargs": {}
+                      }
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ],
+        "Vector Store Tool": [
+          {
+            "startTime": 1730909644235,
+            "executionTime": 953,
+            "executionStatus": "error",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_tool": [
+                [
+                  {
+                    "json": {
+                      "query": "What happened on October 3, 2023?"
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_tool": [
+                [
+                  {
+                    "json": {
+                      "query": "What happened on October 3, 2023?"
+                    }
+                  }
+                ]
+              ]
+            },
+            "error": {
+              "message": "The resource you are requesting could not be found",
+              "timestamp": 1730909645188,
+              "name": "NodeOperationError",
+              "description": "The resource you are requesting could not be found",
+              "context": {},
+              "cause": {
+                "message": "The resource you are requesting could not be found",
+                "timestamp": 1730909645188,
+                "name": "NodeApiError",
+                "description": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+                "context": {},
+                "cause": {
+                  "status": 404,
+                  "headers": {
+                    "alt-svc": "h3=\":443\"; ma=86400",
+                    "cf-cache-status": "DYNAMIC",
+                    "cf-ray": "8de65fe1b90ae522-TXL",
+                    "connection": "keep-alive",
+                    "content-encoding": "gzip",
+                    "content-type": "application/json; charset=utf-8",
+                    "date": "Wed, 06 Nov 2024 16:14:05 GMT",
+                    "server": "cloudflare",
+                    "set-cookie": "__cf_bm=emSz6d0E6qFsEEflxjOUQO23FqtFdjKQPBKoig3owME-1730909645-1.0.1.1-yuVpP2UDcXxcX8ZhxHjMTRTzq8sJqbGif4qkT2GbxCS2mDwrXG_vspy_YTsboRKanwMR5N5JOCbeG3hRBQbaQw; path=/; expires=Wed, 06-Nov-24 16:44:05 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=HQJnJByANdMVV6IaDXfh9eoGVmUagvvbFYMgQ55LNTo-1730909645220-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+                    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+                    "transfer-encoding": "chunked",
+                    "vary": "Origin",
+                    "x-content-type-options": "nosniff",
+                    "x-request-id": "req_3531026ee41a3dfde15fae3f20039748"
+                  },
+                  "request_id": "req_3531026ee41a3dfde15fae3f20039748",
+                  "error": {
+                    "message": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+                    "type": "invalid_request_error",
+                    "param": null,
+                    "code": "model_not_found"
+                  },
+                  "code": "model_not_found",
+                  "param": null,
+                  "type": "invalid_request_error",
+                  "lc_error_code": "MODEL_NOT_FOUND",
+                  "attemptNumber": 1,
+                  "retriesLeft": 2
+                }
+              }
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "Vector Store Tool",
+                  "runIndex": 0
+                }
+              ]
+            }
+          }
+        ],
+        "In-Memory Vector Store": [
+          {
+            "startTime": 1730909644235,
+            "executionTime": 793,
+            "executionStatus": "success",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_vectorStore": [
+                [
+                  {
+                    "json": {
+                      "response": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_vectorStore": [
+                [
+                  {
+                    "json": {
+                      "query": "What happened on October 3, 2023?",
+                      "k": 4
+                    }
+                  }
+                ]
+              ]
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "In-Memory Vector Store",
+                  "runIndex": 0
+                }
+              ]
+            }
+          }
+        ],
+        "Embeddings OpenAI": [
+          {
+            "startTime": 1730909644235,
+            "executionTime": 793,
+            "executionStatus": "success",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_embedding": [
+                [
+                  {
+                    "json": {
+                      "response": [
+                        "json array"
+                      ]
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_embedding": [
+                [
+                  {
+                    "json": {
+                      "query": "What happened on October 3, 2023?"
+                    }
+                  }
+                ]
+              ]
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "Embeddings OpenAI",
+                  "runIndex": 0
+                }
+              ]
+            }
+          }
+        ],
+        "OpenAI Chat Model1": [
+          {
+            "startTime": 1730909645029,
+            "executionTime": 159,
+            "executionStatus": "error",
+            "source": [
+              null
+            ],
+            "data": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "json array"
+                      ],
+                      "estimatedTokens": 52,
+                      "options": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "inputOverride": {
+              "ai_languageModel": [
+                [
+                  {
+                    "json": {
+                      "messages": [
+                        "json array"
+                      ],
+                      "estimatedTokens": 52,
+                      "options": {
+                        "object": true
+                      }
+                    }
+                  }
+                ]
+              ]
+            },
+            "error": {
+              "message": "The resource you are requesting could not be found",
+              "timestamp": 1730909645188,
+              "name": "NodeApiError",
+              "description": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+              "context": {},
+              "cause": {
+                "status": 404,
+                "headers": {
+                  "alt-svc": "h3=\":443\"; ma=86400",
+                  "cf-cache-status": "DYNAMIC",
+                  "cf-ray": "8de65fe1b90ae522-TXL",
+                  "connection": "keep-alive",
+                  "content-encoding": "gzip",
+                  "content-type": "application/json; charset=utf-8",
+                  "date": "Wed, 06 Nov 2024 16:14:05 GMT",
+                  "server": "cloudflare",
+                  "set-cookie": "__cf_bm=emSz6d0E6qFsEEflxjOUQO23FqtFdjKQPBKoig3owME-1730909645-1.0.1.1-yuVpP2UDcXxcX8ZhxHjMTRTzq8sJqbGif4qkT2GbxCS2mDwrXG_vspy_YTsboRKanwMR5N5JOCbeG3hRBQbaQw; path=/; expires=Wed, 06-Nov-24 16:44:05 GMT; domain=.api.openai.com; HttpOnly; Secure; SameSite=None, _cfuvid=HQJnJByANdMVV6IaDXfh9eoGVmUagvvbFYMgQ55LNTo-1730909645220-0.0.1.1-604800000; path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None",
+                  "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+                  "transfer-encoding": "chunked",
+                  "vary": "Origin",
+                  "x-content-type-options": "nosniff",
+                  "x-request-id": "req_3531026ee41a3dfde15fae3f20039748"
+                },
+                "request_id": "req_3531026ee41a3dfde15fae3f20039748",
+                "error": {
+                  "message": "The model `gpt-4o-mini123` does not exist or you do not have access to it.",
+                  "type": "invalid_request_error",
+                  "param": null,
+                  "code": "model_not_found"
+                },
+                "code": "model_not_found",
+                "param": null,
+                "type": "invalid_request_error",
+                "lc_error_code": "MODEL_NOT_FOUND",
+                "attemptNumber": 1,
+                "retriesLeft": 2
+              }
+            },
+            "metadata": {
+              "subRun": [
+                {
+                  "node": "OpenAI Chat Model1",
+                  "runIndex": 0
+                }
+              ]
+            }
+          }
+        ],
+        "AI Agent": [
+          {
+            "hints": [],
+            "startTime": 1730909642645,
+            "executionTime": 3428,
+            "source": [
+              {
+                "previousNode": "When clicking ‘Test workflow’"
+              }
+            ],
+            "executionStatus": "success",
+            "data": {
+              "main": [
+                [
+                  {
+                    "json": {
+                      "output": "I couldn't find any specific events that happened yesterday, October 3, 2023. Please let me know if you're looking for information on a particular topic or event!"
+                    },
+                    "pairedItem": {
+                      "item": 0
+                    }
+                  }
+                ]
+              ]
+            }
+          }
+        ]
+      },
+      "lastNodeExecuted": "AI Agent"
+    },
+    "executionData": {
+      "contextData": {},
+      "nodeExecutionStack": [],
+      "metadata": {
+        "OpenAI Chat Model": [
+          {
+            "subRun": [
+              {
+                "node": "OpenAI Chat Model",
+                "runIndex": 0
+              },
+              {
+                "node": "OpenAI Chat Model",
+                "runIndex": 1
+              }
+            ]
+          }
+        ],
+        "Embeddings OpenAI": [
+          {
+            "subRun": [
+              {
+                "node": "Embeddings OpenAI",
+                "runIndex": 0
+              }
+            ]
+          }
+        ],
+        "In-Memory Vector Store": [
+          {
+            "subRun": [
+              {
+                "node": "In-Memory Vector Store",
+                "runIndex": 0
+              }
+            ]
+          }
+        ],
+        "OpenAI Chat Model1": [
+          {
+            "subRun": [
+              {
+                "node": "OpenAI Chat Model1",
+                "runIndex": 0
+              }
+            ]
+          }
+        ],
+        "Vector Store Tool": [
+          {
+            "subRun": [
+              {
+                "node": "Vector Store Tool",
+                "runIndex": 0
+              }
+            ]
+          }
+        ]
+      },
+      "waitingExecution": {},
+      "waitingExecutionSource": {}
+    }
+  },
+  "mode": "cli",
+  "startedAt": "2024-11-06T16:14:02.643Z",
+  "stoppedAt": "2024-11-06T16:14:06.073Z",
+  "status": "running",
+  "finished": true
+}

--- a/workflows/255.json
+++ b/workflows/255.json
@@ -1,0 +1,86 @@
+{
+  "name": "Sub-node errors:model",
+  "nodes": [
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ],
+      "id": "077f1a05-32d1-4a9e-abd9-9ef4a1bcfe02",
+      "name": "When clicking ‘Test workflow’"
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "Hey"
+      },
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "typeVersion": 1.4,
+      "position": [
+        200,
+        0
+      ],
+      "id": "5c3f329d-6481-41c5-9747-e9fd53815ca6",
+      "name": "Basic LLM Chain",
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "model": "=gpt-4o-mini123",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1,
+      "position": [
+        280,
+        220
+      ],
+      "id": "00cb1410-f04f-4b2b-b42e-f2c275ba0b4a",
+      "name": "OpenAI Chat Model",
+      "credentials": {
+        "openAiApi": {
+          "id": "Zak03cqeLUOsgkFI",
+          "name": "OpenAi account"
+        }
+      }
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Basic LLM Chain",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "56e5e220-edbd-4d7a-97f3-96b8cf952202",
+  "meta": {
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "255",
+  "tags": []
+}

--- a/workflows/256.json
+++ b/workflows/256.json
@@ -1,0 +1,193 @@
+{
+  "name": "Nested sub-node errors:model",
+  "nodes": [
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "What happened yesterday?",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 1.7,
+      "position": [
+        140,
+        -60
+      ],
+      "id": "17f481ed-343f-4e0f-ace0-ec1a6937f57d",
+      "name": "AI Agent"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1,
+      "position": [
+        100,
+        180
+      ],
+      "id": "af60b8a2-f065-46e5-92c6-2b3f54e8b48d",
+      "name": "OpenAI Chat Model",
+      "credentials": {
+        "openAiApi": {
+          "id": "Zak03cqeLUOsgkFI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "name": "search_vector_store",
+        "description": "Retrieves data about past events"
+      },
+      "type": "@n8n/n8n-nodes-langchain.toolVectorStore",
+      "typeVersion": 1,
+      "position": [
+        400,
+        160
+      ],
+      "id": "3d2dc985-7dc5-4996-90c5-85e777070315",
+      "name": "Vector Store Tool"
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.embeddingsOpenAi",
+      "typeVersion": 1.1,
+      "position": [
+        360,
+        520
+      ],
+      "id": "55cfa84c-b2f6-40aa-9eef-43fec740ba6c",
+      "name": "Embeddings OpenAI",
+      "credentials": {
+        "openAiApi": {
+          "id": "Zak03cqeLUOsgkFI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "model": "=gpt-4o-mini123",
+        "options": {}
+      },
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1,
+      "position": [
+        620,
+        360
+      ],
+      "id": "46468ea7-318b-4893-b387-b8cc1cca1355",
+      "name": "OpenAI Chat Model1",
+      "credentials": {
+        "openAiApi": {
+          "id": "Zak03cqeLUOsgkFI",
+          "name": "OpenAi account"
+        }
+      }
+    },
+    {
+      "parameters": {},
+      "type": "@n8n/n8n-nodes-langchain.vectorStoreInMemory",
+      "typeVersion": 1,
+      "position": [
+        300,
+        320
+      ],
+      "id": "e3a35d71-b47d-46fc-976e-eb671cc9c3fc",
+      "name": "In-Memory Vector Store"
+    },
+    {
+      "parameters": {},
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        -60,
+        -60
+      ],
+      "id": "b42f6a79-4b29-4e17-95ab-5c4fbeda3683",
+      "name": "When clicking ‘Test workflow’"
+    }
+  ],
+  "pinData": {},
+  "connections": {
+    "OpenAI Chat Model": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Vector Store Tool": {
+      "ai_tool": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "ai_tool",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Embeddings OpenAI": {
+      "ai_embedding": [
+        [
+          {
+            "node": "In-Memory Vector Store",
+            "type": "ai_embedding",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Chat Model1": {
+      "ai_languageModel": [
+        [
+          {
+            "node": "Vector Store Tool",
+            "type": "ai_languageModel",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "In-Memory Vector Store": {
+      "ai_vectorStore": [
+        [
+          {
+            "node": "Vector Store Tool",
+            "type": "ai_vectorStore",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "When clicking ‘Test workflow’": {
+      "main": [
+        [
+          {
+            "node": "AI Agent",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "versionId": "5b6e4b0f-73c8-4254-8b3e-aa36f3e5ae4e",
+  "meta": {
+    "instanceId": "27cc9b56542ad45b38725555722c50a1c3fee1670bbb67980558314ee08517c4"
+  },
+  "id": "256",
+  "tags": []
+}


### PR DESCRIPTION
## Summary
This PR adds a couple of tests to check the state of the workflow when LLM sub-node throws an error.

## Related tickets and PRs
- https://github.com/n8n-io/n8n/pull/11418
- https://linear.app/n8n/issue/AI-298/errors-happen-in-the-root-node-not-in-the-sub-node-even-if-it-belongs